### PR TITLE
fix(ci): remove continue-on-error from GHCR publish; add on:release trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,7 +200,6 @@ jobs:
   publish:
     name: Publish (${{ matrix.arch }})
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    continue-on-error: true   # advisory until GHCR org package-write permission is confirmed
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
@@ -240,7 +239,6 @@ jobs:
     name: Publish manifest
     needs: [publish]
     if: ${{ !cancelled() && needs.publish.result != 'skipped' }}
-    continue-on-error: true   # advisory until GHCR org package-write permission is confirmed
     runs-on: ubuntu-latest
     permissions:
       packages: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,11 @@
 name: Release – Docker Build & Publish
 
 on:
+  # Fires automatically when release-please publishes a GitHub Release (creates the tag).
+  # This is the primary trigger — no manual dispatch needed in normal flow.
+  release:
+    types: [published]
+  # Manual fallback: re-run for a specific tag (e.g. after a failed automatic run).
   workflow_dispatch:
     inputs:
       tag:
@@ -15,7 +20,8 @@ permissions:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  RELEASE_TAG: ${{ inputs.tag }}
+  # On release event use the published tag; on manual dispatch use the input.
+  RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
 
 jobs:
   # ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

Container image publish has been silently failing since repo creation. The `publish` and `publish-manifest` jobs in `ci.yml` had `continue-on-error: true` which masked a `permission_denied: write_package` error on every push to `main`. No images have ever been pushed to GHCR.

Additionally, `release.yml` was only triggered by `workflow_dispatch` dispatched from `release-please.yml`. If that dispatch races or fails, no release build runs.

## Changes

**`ci.yml`**
- Removed `continue-on-error: true` from `publish` and `publish-manifest` jobs — failures are now visible

**`release.yml`**
- Added `on: release: types: [published]` as primary trigger — fires automatically when release-please publishes a GitHub Release
- `RELEASE_TAG` now resolves from `github.event.release.tag_name` (release event) or `inputs.tag` (manual dispatch)
- `workflow_dispatch` remains as manual fallback for re-runs

## Required admin action

Before pushes to GHCR will succeed, an org admin must enable **"Read and write permissions"** for Actions at:
`https://github.com/organizations/NorthlandPositronics/settings/actions`

Once enabled, re-run the release workflow for `v0.1.8`:
```bash
gh workflow run release.yml --repo NorthlandPositronics/Cogtrix-WebUI -f tag=v0.1.8
```

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)