### PR TITLE
next → main (v0.1.9)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,7 +200,6 @@ jobs:
   publish:
     name: Publish (${{ matrix.arch }})
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    continue-on-error: true   # advisory until GHCR org package-write permission is confirmed
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
@@ -240,7 +239,6 @@ jobs:
     name: Publish manifest
     needs: [publish]
     if: ${{ !cancelled() && needs.publish.result != 'skipped' }}
-    continue-on-error: true   # advisory until GHCR org package-write permission is confirmed
     runs-on: ubuntu-latest
     permissions:
       packages: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,11 @@
 name: Release – Docker Build & Publish
 
 on:
+  # Fires automatically when release-please publishes a GitHub Release (creates the tag).
+  # This is the primary trigger — no manual dispatch needed in normal flow.
+  release:
+    types: [published]
+  # Manual fallback: re-run for a specific tag (e.g. after a failed automatic run).
   workflow_dispatch:
     inputs:
       tag:
@@ -15,7 +20,8 @@ permissions:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  RELEASE_TAG: ${{ inputs.tag }}
+  # On release event use the published tag; on manual dispatch use the input.
+  RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
 
 jobs:
   # ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **fix(ci):** remove `continue-on-error` from GHCR publish jobs — failures now visible instead of silently swallowed
- **fix(ci):** add `on: release: types: [published]` trigger to `release.yml` — Docker build pipeline auto-fires when release-please publishes a tag; `RELEASE_TAG` resolves from release event or manual dispatch input

## Required admin action after merge

Enable **"Read and write permissions"** for Actions at:
`https://github.com/organizations/NorthlandPositronics/settings/actions`

Then re-run the release for the already-published v0.1.8 tag:
```bash
gh workflow run release.yml --repo NorthlandPositronics/Cogtrix-WebUI -f tag=v0.1.8
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)