### PR TITLE
fix(webui): comprehensive correctness sweep — streaming, API contract, races, a11y, perf

### DIFF
--- a/cypress/e2e/streaming.cy.ts
+++ b/cypress/e2e/streaming.cy.ts
@@ -151,13 +151,13 @@ describe("Streaming & WebSocket", () => {
       );
     });
 
-    it("streaming cursor is visible during stream and hidden after done", () => {
+    it("streaming bubble is visible during stream and gone after done", () => {
       cy.then(() => {
         injectMessage("agent_state", { state: "writing" });
         injectMessage("token", { text: "Response text", final: false });
       });
 
-      cy.get("[data-cy='streaming-cursor']", { timeout: 10000 }).should("exist");
+      cy.get("[data-cy='streaming-message']", { timeout: 10000 }).should("exist");
 
       cy.then(() => {
         injectMessage("done", {
@@ -171,7 +171,7 @@ describe("Streaming & WebSocket", () => {
         injectMessage("agent_state", { state: "idle" });
       });
 
-      cy.get("[data-cy='streaming-cursor']").should("not.exist");
+      cy.get("[data-cy='streaming-message']").should("not.exist");
     });
   });
 
@@ -305,15 +305,17 @@ describe("Streaming & WebSocket", () => {
         injectMessage("token", { text: "Partial response...", final: false });
       });
 
-      cy.get("[data-cy='streaming-cursor']", { timeout: 10000 }).should("exist");
+      cy.get("[data-cy='streaming-message']", { timeout: 10000 }).should("exist");
 
       cy.then(() => {
         mockWs.readyState = 3;
         mockWs.onclose?.({ code: 1006 } as CloseEvent);
       });
 
-      // Connection status should reflect disconnection
-      cy.get("[role='status']", { timeout: 10000 }).should("exist");
+      // Connection status should reflect disconnection. Target the status dot
+      // specifically — `[role='status']` also matches the streaming bubble, the
+      // typing indicator and the agent-state badge, so it would pass vacuously.
+      cy.get("[data-cy='connection-status']", { timeout: 10000 }).should("exist");
     });
 
     it("sends cancel message when stop button is clicked during streaming", () => {
@@ -322,7 +324,7 @@ describe("Streaming & WebSocket", () => {
         injectMessage("token", { text: "Generating...", final: false });
       });
 
-      cy.get("[data-cy='streaming-cursor']", { timeout: 10000 }).should("exist");
+      cy.get("[data-cy='streaming-message']", { timeout: 10000 }).should("exist");
       cy.get("[data-cy='cancel-generation']").should("be.visible").click();
 
       cy.wrap(null, { timeout: 5000 }).should(() => {

--- a/docs/web/design-system.md
+++ b/docs/web/design-system.md
@@ -366,6 +366,15 @@ font-mono, text-sm, leading-relaxed
 bg-zinc-50, border border-zinc-200, rounded-md, p-3
 ```
 
+**Shell/terminal blocks** — code fences with language `bash`, `sh`, `shell`, `zsh`, `fish`, `console`, `terminal`, `output`, `powershell`, `cmd`, `batch` use a dark terminal surface to visually distinguish command/output from regular code:
+
+```
+font-mono, text-sm, leading-relaxed, text-zinc-100
+bg-zinc-900 body, bg-zinc-800 header, border border-zinc-700, rounded-md
+```
+
+Implemented as `ShellBlock` in `src/components/MarkdownComponents.tsx`. Shares copy-button header pattern with `CodeBlock` and `YamlBlock`.
+
 ---
 
 ## 3. Spacing

--- a/src/components/MarkdownComponents.tsx
+++ b/src/components/MarkdownComponents.tsx
@@ -64,10 +64,15 @@ function ShellBlock({ children, language }: { children: ReactNode; language?: st
 
   function handleCopy() {
     const text = extractText(children);
-    void navigator.clipboard.writeText(text).then(() => {
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    });
+    // A rejected write (insecure context, denied permission) must not become an
+    // unhandled rejection — leave the button unflipped so it reads as "not copied".
+    void navigator.clipboard
+      .writeText(text)
+      .then(() => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      })
+      .catch(() => setCopied(false));
   }
 
   return (
@@ -100,10 +105,15 @@ function CodeBlock({ children, language }: { children: ReactNode; language?: str
 
   function handleCopy() {
     const text = extractText(children);
-    void navigator.clipboard.writeText(text).then(() => {
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    });
+    // A rejected write (insecure context, denied permission) must not become an
+    // unhandled rejection — leave the button unflipped so it reads as "not copied".
+    void navigator.clipboard
+      .writeText(text)
+      .then(() => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      })
+      .catch(() => setCopied(false));
   }
 
   return (
@@ -230,7 +240,10 @@ export const markdownComponents: Components = {
     return <CodeBlock language={language}>{children}</CodeBlock>;
   },
   code({ children, className }) {
-    const isInline = !className;
+    // A fenced block's <code> carries a trailing newline; inline code never does.
+    // Without that check a language-less ``` fence (which also has no className)
+    // was treated as inline and rendered as a pill nested inside the block <pre>.
+    const isInline = !className && !String(children).includes("\n");
     if (isInline) {
       return (
         <code className="rounded bg-zinc-100 px-1 py-0.5 font-mono text-sm text-zinc-900">

--- a/src/components/MarkdownComponents.tsx
+++ b/src/components/MarkdownComponents.tsx
@@ -45,6 +45,56 @@ function extractText(node: ReactNode): string {
   return "";
 }
 
+const SHELL_LANGUAGES = new Set([
+  "bash",
+  "sh",
+  "shell",
+  "zsh",
+  "fish",
+  "console",
+  "terminal",
+  "output",
+  "powershell",
+  "cmd",
+  "batch",
+]);
+
+function ShellBlock({ children, language }: { children: ReactNode; language?: string }) {
+  const [copied, setCopied] = useState(false);
+
+  function handleCopy() {
+    const text = extractText(children);
+    void navigator.clipboard.writeText(text).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  }
+
+  return (
+    <div className="overflow-hidden rounded-md border border-zinc-700">
+      <div className="flex items-center justify-between bg-zinc-800 px-3 py-1.5">
+        <span className="font-mono text-xs font-medium text-zinc-400">{language ?? "shell"}</span>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-6 w-6 text-zinc-400 hover:bg-zinc-700 hover:text-zinc-100"
+          onClick={handleCopy}
+          aria-label={copied ? "Copied" : "Copy code"}
+        >
+          {copied ? (
+            <Check className="h-3.5 w-3.5 text-green-400" />
+          ) : (
+            <Clipboard className="h-3.5 w-3.5" />
+          )}
+        </Button>
+      </div>
+      <pre className="overflow-x-auto bg-zinc-900 px-3 py-3 font-mono text-sm leading-relaxed text-zinc-100">
+        {children}
+      </pre>
+    </div>
+  );
+}
+
 function CodeBlock({ children, language }: { children: ReactNode; language?: string }) {
   const [copied, setCopied] = useState(false);
 
@@ -174,6 +224,9 @@ export const markdownComponents: Components = {
         : "";
     const language = langClass.startsWith("language-") ? langClass.slice(9) : undefined;
 
+    if (language && SHELL_LANGUAGES.has(language)) {
+      return <ShellBlock language={language}>{children}</ShellBlock>;
+    }
     return <CodeBlock language={language}>{children}</CodeBlock>;
   },
   code({ children, className }) {

--- a/src/components/SessionCard.tsx
+++ b/src/components/SessionCard.tsx
@@ -1,4 +1,4 @@
-import { memo, type MouseEvent, type KeyboardEvent } from "react";
+import { memo, useState, type MouseEvent, type KeyboardEvent } from "react";
 import { useNavigate } from "react-router-dom";
 import { ArchiveRestore, CheckCircle2, ChevronDown, Trash2 } from "lucide-react";
 import { AgentStateBadge } from "@/components/AgentStateBadge";
@@ -7,7 +7,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { cn } from "@/lib/utils";
+import { cn, parseServerDate } from "@/lib/utils";
 import type { SessionOut } from "@/lib/api/types/session";
 import type { ModelOut } from "@/lib/api/types/config";
 
@@ -32,7 +32,7 @@ interface SessionRowProps {
 }
 
 function formatRelativeTime(isoString: string): string {
-  const date = new Date(isoString);
+  const date = parseServerDate(isoString);
   const now = new Date();
   const diffMs = now.getTime() - date.getTime();
   const diffSeconds = Math.floor(diffMs / 1000);
@@ -64,8 +64,13 @@ function ModelPopover({
   models,
   onEditModel,
 }: ModelPopoverProps) {
+  // Controlled + close-on-select: the option buttons had no pending gate, so a
+  // second click before the first PATCH resolved issued two concurrent
+  // /sessions/{id} updates whose apply order decided the winner. Closing on
+  // select makes a second selection from the same popover impossible.
+  const [open, setOpen] = useState(false);
   return (
-    <Popover>
+    <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
         <button
           className="focus-visible:ring-ring -mx-1 flex items-center gap-1 rounded px-1 text-sm text-zinc-500 hover:bg-zinc-100 focus-visible:ring-2 focus-visible:ring-offset-1 focus-visible:outline-none"
@@ -90,6 +95,7 @@ function ModelPopover({
                 if (m.alias !== currentModel) {
                   onEditModel(sessionId, m.alias);
                 }
+                setOpen(false);
               }}
               aria-pressed={m.alias === currentModel}
             >

--- a/src/components/YamlBlock.tsx
+++ b/src/components/YamlBlock.tsx
@@ -17,10 +17,15 @@ export function YamlBlock({ code, filename = "cogtrix.yaml" }: YamlBlockProps) {
   const anchorRef = useRef<HTMLAnchorElement>(null);
 
   function handleCopy() {
-    void navigator.clipboard.writeText(code).then(() => {
-      setCopied(true);
-      setTimeout(() => setCopied(false), 1500);
-    });
+    // A rejected write (insecure context, denied permission) must not become an
+    // unhandled rejection — leave the button unflipped so it reads as "not copied".
+    void navigator.clipboard
+      .writeText(code)
+      .then(() => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1500);
+      })
+      .catch(() => setCopied(false));
   }
 
   function handleDownload() {
@@ -31,7 +36,9 @@ export function YamlBlock({ code, filename = "cogtrix.yaml" }: YamlBlockProps) {
       anchorRef.current.download = filename;
       anchorRef.current.click();
     }
-    URL.revokeObjectURL(url);
+    // Revoking in the same tick can invalidate the blob before the browser has
+    // started reading it — Firefox/Safari then silently download nothing.
+    setTimeout(() => URL.revokeObjectURL(url), 0);
   }
 
   return (

--- a/src/hooks/assistant/useAssistantChatMessagesQuery.ts
+++ b/src/hooks/assistant/useAssistantChatMessagesQuery.ts
@@ -8,7 +8,9 @@ export function useAssistantChatMessagesQuery(chatKey: string | null) {
   return useQuery({
     queryKey: keys.assistant.chatMessages(chatKey ?? ""),
     queryFn: async () => {
-      const page = await api.get<CursorPage<MessageOut>>(`/assistant/chats/${chatKey}/messages`);
+      const page = await api.get<CursorPage<MessageOut>>(
+        `/assistant/chats/${encodeURIComponent(chatKey!)}/messages`,
+      );
       return page.items;
     },
     enabled: chatKey !== null,

--- a/src/hooks/assistant/useWorkflowsQuery.ts
+++ b/src/hooks/assistant/useWorkflowsQuery.ts
@@ -18,7 +18,10 @@ export function useWorkflowsQuery() {
 export function useWorkflowDocumentsQuery(workflowId: string | null) {
   return useQuery<WorkflowDocumentOut[]>({
     queryKey: keys.workflows.documents(workflowId ?? ""),
-    queryFn: () => api.get<WorkflowDocumentOut[]>(`/assistant/workflows/${workflowId!}/documents`),
+    queryFn: () =>
+      api.get<WorkflowDocumentOut[]>(
+        `/assistant/workflows/${encodeURIComponent(workflowId!)}/documents`,
+      ),
     enabled: workflowId !== null,
   });
 }

--- a/src/hooks/chat/useSessionSocket.ts
+++ b/src/hooks/chat/useSessionSocket.ts
@@ -41,6 +41,9 @@ export function useSessionSocket(
   const socketRef = useRef<SessionSocket | null>(null);
   const cancelTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const watchdogRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Lets confirmTool (defined outside the socket effect) re-arm the hang
+  // watchdog once the user answers a tool-confirmation prompt.
+  const startWatchdogRef = useRef<(() => void) | null>(null);
   const queryClient = useQueryClient();
   const optionsRef = useRef(options);
   optionsRef.current = options;
@@ -73,6 +76,7 @@ export function useSessionSocket(
         watchdogRef.current = null;
       }
     }
+    startWatchdogRef.current = startWatchdog;
 
     // Imperative health probe passed to SessionSocket's reconnect logic — intentionally
     // outside TanStack Query since it is a fire-and-forget liveness check with no
@@ -93,6 +97,12 @@ export function useSessionSocket(
           getStore().appendToken(text);
         },
 
+        onDiscardPending: () => {
+          // Server regenerated the final answer after verification-recovery —
+          // drop what we've streamed so far; the surviving generation follows.
+          getStore().clearStreamingBuffer();
+        },
+
         onToolStart: (tool, toolCallId, input) => {
           getStore().addToolStart(tool, toolCallId, input);
         },
@@ -102,6 +112,10 @@ export function useSessionSocket(
         },
 
         onToolConfirmRequest: (payload) => {
+          // The agent is now blocked waiting on the user — stop the hang
+          // watchdog so a slow human decision isn't mistaken for a stalled turn.
+          // It re-arms in confirmTool when the user answers.
+          clearWatchdog();
           getStore().setPendingConfirmation(payload);
         },
 
@@ -152,6 +166,14 @@ export function useSessionSocket(
         },
 
         onError: (code, message) => {
+          if (code === "TURN_IN_PROGRESS") {
+            // A second send was rejected while a turn is still running. The live
+            // turn is unaffected — do NOT clear its watchdog or reset streaming
+            // state. Just warn and drop the phantom optimistic user message.
+            toast.warning("Please wait for the response to complete.");
+            void queryClient.invalidateQueries({ queryKey: keys.messages.list(sessionId) });
+            return;
+          }
           clearWatchdog();
           if (cancelTimerRef.current) {
             clearTimeout(cancelTimerRef.current);
@@ -159,8 +181,6 @@ export function useSessionSocket(
           }
           if (code === "CANCELLED") {
             getStore().reset();
-          } else if (code === "TURN_IN_PROGRESS") {
-            toast.warning("Please wait for the response to complete.");
           } else {
             getStore().reset();
             getStore().setAgentState("error");
@@ -232,6 +252,11 @@ export function useSessionSocket(
       }
       socketRef.current = null;
       getStore().reset();
+      // reset() deliberately preserves connectionStatus, so without this the
+      // store still reads "open" after the socket is gone — which leaves the
+      // composer enabled and lets a send silently no-op while still writing an
+      // optimistic user message that never gets answered.
+      getStore().setConnectionStatus("closed");
       getStore().clearStatusLog();
     };
     // queryClient and navigate are stable references — omitting from deps is intentional
@@ -242,6 +267,20 @@ export function useSessionSocket(
     (text: string, mode: "normal" | "think" | "delegate") => {
       socketRef.current?.sendMessage(text, mode);
       getStore().setCurrentMode(mode);
+
+      // A previous turn's invalidation may still be refetching (an infinite query
+      // refetches every loaded page serially, so the window is ~0.5-1 s). Without
+      // cancelling, that response lands after the optimistic write below and
+      // replaces the cache wholesale — the message the user just sent disappears
+      // from the transcript until the next turn completes.
+      void queryClient.cancelQueries({ queryKey: keys.messages.list(sessionId) });
+
+      // A stale cancel-fallback timer from an earlier turn would otherwise fire
+      // mid-way through this one and reset live streaming state (see cancel()).
+      if (cancelTimerRef.current) {
+        clearTimeout(cancelTimerRef.current);
+        cancelTimerRef.current = null;
+      }
 
       // Optimistic: insert the user message into the cache immediately
       const messageKey = keys.messages.list(sessionId);
@@ -277,24 +316,9 @@ export function useSessionSocket(
     [sessionId, queryClient],
   );
 
-  const confirmTool = useCallback(
-    (confirmationId: string, action: ToolConfirmPayload["action"]) => {
-      socketRef.current?.confirmTool(confirmationId, action);
-      getStore().setPendingConfirmation(null);
-    },
-    [],
-  );
-
-  const cancel = useCallback(() => {
-    socketRef.current?.cancel();
-
-    // Cancel also clears the watchdog — we're explicitly stopping the turn
-    if (watchdogRef.current) {
-      clearTimeout(watchdogRef.current);
-      watchdogRef.current = null;
-    }
-
-    // Force-reset after timeout if server never responds to cancel
+  // Force-reset if the server never acts on a cancel (delivery ≠ processing).
+  // Shared by the composer Cancel and the confirmation-modal "cancel" action.
+  const armCancelFallback = useCallback(() => {
     if (cancelTimerRef.current) clearTimeout(cancelTimerRef.current);
     cancelTimerRef.current = setTimeout(() => {
       cancelTimerRef.current = null;
@@ -307,6 +331,44 @@ export function useSessionSocket(
       }
     }, 5_000);
   }, [sessionId, queryClient]);
+
+  const confirmTool = useCallback(
+    (confirmationId: string, action: ToolConfirmPayload["action"]) => {
+      const delivered = socketRef.current?.confirmTool(confirmationId, action) ?? false;
+      if (!delivered) {
+        // The socket was down (the agent is blocked on the user, so the idle
+        // connection can be dropped while the prompt is open). Keep the prompt
+        // open — closing it here would leave the user believing they approved
+        // the tool, and the turn would only fail 5 minutes later via the watchdog.
+        toast.error("Connection lost — reconnect and answer the prompt again.");
+        return;
+      }
+      getStore().setPendingConfirmation(null);
+      if (action === "cancel") {
+        // Cancelling the turn: the watchdog stays off, so arm the same 5 s
+        // fallback the composer Cancel uses — otherwise a cancel the server never
+        // processes leaves the composer disabled in a running state forever.
+        armCancelFallback();
+      } else {
+        // The agent resumes on allow/deny/allow_all/disable/forbid_all — re-arm
+        // the hang watchdog that onToolConfirmRequest cleared.
+        startWatchdogRef.current?.();
+      }
+    },
+    [armCancelFallback],
+  );
+
+  const cancel = useCallback(() => {
+    socketRef.current?.cancel();
+
+    // Cancel also clears the watchdog — we're explicitly stopping the turn
+    if (watchdogRef.current) {
+      clearTimeout(watchdogRef.current);
+      watchdogRef.current = null;
+    }
+
+    armCancelFallback();
+  }, [armCancelFallback]);
 
   return {
     sendMessage,

--- a/src/hooks/shared/useDocumentsQuery.ts
+++ b/src/hooks/shared/useDocumentsQuery.ts
@@ -15,8 +15,11 @@ export function useDocumentsQuery() {
     getNextPageParam: (lastPage: CursorPage<DocumentOut>) => lastPage.next_cursor ?? undefined,
     initialPageParam: null as string | null,
     refetchInterval: (query) => {
+      // Poll only while something is genuinely in progress. chunk_count === 0 was
+      // used as a proxy, but that's also the resting state of failed and empty
+      // documents — so the list re-fetched forever. status is the real signal.
       const hasProcessing = query.state.data?.pages.some((page) =>
-        page.items.some((doc) => doc.chunk_count === 0),
+        page.items.some((doc) => doc.status === "pending" || doc.status === "processing"),
       );
       return hasProcessing ? 15_000 : false;
     },

--- a/src/hooks/shared/useLiveUptime.ts
+++ b/src/hooks/shared/useLiveUptime.ts
@@ -1,4 +1,4 @@
-import { useMemo, useSyncExternalStore } from "react";
+import { useState, useSyncExternalStore } from "react";
 import { formatUptime } from "@/lib/utils";
 
 let tick = 0;
@@ -28,11 +28,15 @@ function getSnapshot(): number {
 
 export function useLiveUptime(baseSeconds: number | undefined, dataUpdatedAt: number): string {
   const currentTick = useSyncExternalStore(subscribe, getSnapshot);
-  // Capture the tick value when dataUpdatedAt changes (i.e. when fresh data arrives).
-  // dataUpdatedAt is intentionally the only dep — tick is read as a side effect to snapshot it.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const anchorTick = useMemo(() => tick, [dataUpdatedAt]);
+  // Anchor the tick at the moment fresh data arrived. useMemo must NOT be used
+  // here: React may discard a memo and recompute it for unchanged deps, which
+  // would re-anchor to "now" and make the displayed uptime jump backward toward
+  // baseSeconds. This is the documented adjust-state-when-props-change pattern.
+  const [anchor, setAnchor] = useState({ updatedAt: dataUpdatedAt, tick: currentTick });
+  if (anchor.updatedAt !== dataUpdatedAt) {
+    setAnchor({ updatedAt: dataUpdatedAt, tick: currentTick });
+  }
 
   if (baseSeconds === undefined) return "—";
-  return formatUptime(baseSeconds + Math.max(0, currentTick - anchorTick));
+  return formatUptime(baseSeconds + Math.max(0, currentTick - anchor.tick));
 }

--- a/src/hooks/shared/useSound.ts
+++ b/src/hooks/shared/useSound.ts
@@ -1,3 +1,4 @@
+import { useCallback } from "react";
 import { useUIStore } from "@/lib/stores/ui-store";
 
 // Module-level singleton — not recreated on re-renders or remounts
@@ -44,6 +45,13 @@ function playTone(
 
   osc.start(ctx.currentTime + startOffset);
   osc.stop(ctx.currentTime + startOffset + duration);
+  // Release the graph once the tone ends — the AudioContext is a long-lived
+  // module singleton, so without this the destination's input list grows for
+  // every chime played over the life of the tab.
+  osc.onended = () => {
+    osc.disconnect();
+    gainNode.disconnect();
+  };
 }
 
 export interface SoundHook {
@@ -56,52 +64,58 @@ export interface SoundHook {
 export function useSound(): SoundHook {
   const soundEnabled = useUIStore((s) => s.soundEnabled);
 
-  function playResponseComplete(): void {
+  // Stable identities keyed on soundEnabled — consumers list these in effect
+  // deps (SessionPage, AssistantChatList), so fresh identities each render made
+  // those effects re-run every render.
+  const playResponseComplete = useCallback(() => {
     if (!soundEnabled) return;
     const ctx = getAudioContext();
     if (!ctx) return;
-    void resumeIfSuspended(ctx).then(() => {
-      // EVT-001: Two-note ascending chime, major second interval
-      // First note: ~1200 Hz, second note: ~1350 Hz (major second up)
-      // Total ~220 ms, gain 0.25
-      playTone(ctx, 1200, 0.25, 0, 0.12);
-      playTone(ctx, 1350, 0.25, 0.1, 0.12);
-    });
-  }
+    void resumeIfSuspended(ctx)
+      .then(() => {
+        // EVT-001: Two-note ascending chime, major second interval
+        playTone(ctx, 1200, 0.25, 0, 0.12);
+        playTone(ctx, 1350, 0.25, 0.1, 0.12);
+      })
+      .catch(() => {});
+  }, [soundEnabled]);
 
-  function playError(): void {
+  const playError = useCallback(() => {
     if (!soundEnabled) return;
     const ctx = getAudioContext();
     if (!ctx) return;
-    void resumeIfSuspended(ctx).then(() => {
-      // EVT-002: Two descending tones, slightly lower than EVT-001
-      // First note: ~900 Hz, second note: ~780 Hz (minor second down)
-      // Total ~220 ms, gain 0.30
-      playTone(ctx, 900, 0.3, 0, 0.12);
-      playTone(ctx, 780, 0.3, 0.1, 0.12);
-    });
-  }
+    void resumeIfSuspended(ctx)
+      .then(() => {
+        // EVT-002: Two descending tones, slightly lower than EVT-001
+        playTone(ctx, 900, 0.3, 0, 0.12);
+        playTone(ctx, 780, 0.3, 0.1, 0.12);
+      })
+      .catch(() => {});
+  }, [soundEnabled]);
 
-  function playInboundChat(): void {
+  const playInboundChat = useCallback(() => {
     if (!soundEnabled) return;
     const ctx = getAudioContext();
     if (!ctx) return;
-    void resumeIfSuspended(ctx).then(() => {
-      // EVT-003: Single low-pitched soft tone, ~150 ms
-      // Lower frequency to distinguish from EVT-001, gain 0.20
-      playTone(ctx, 660, 0.2, 0, 0.15);
-    });
-  }
+    void resumeIfSuspended(ctx)
+      .then(() => {
+        // EVT-003: Single low-pitched soft tone, ~150 ms
+        playTone(ctx, 660, 0.2, 0, 0.15);
+      })
+      .catch(() => {});
+  }, [soundEnabled]);
 
-  function playDestructiveConfirm(): void {
+  const playDestructiveConfirm = useCallback(() => {
     if (!soundEnabled) return;
     const ctx = getAudioContext();
     if (!ctx) return;
-    void resumeIfSuspended(ctx).then(() => {
-      // EVT-004: Single mid-pitched short click, ~80 ms, no decay tail
-      playTone(ctx, 800, 0.2, 0, 0.08);
-    });
-  }
+    void resumeIfSuspended(ctx)
+      .then(() => {
+        // EVT-004: Single mid-pitched short click, ~80 ms, no decay tail
+        playTone(ctx, 800, 0.2, 0, 0.08);
+      })
+      .catch(() => {});
+  }, [soundEnabled]);
 
   return { playResponseComplete, playError, playInboundChat, playDestructiveConfirm };
 }

--- a/src/index.css
+++ b/src/index.css
@@ -113,21 +113,6 @@
   }
 }
 
-@keyframes blink-cursor {
-  0%,
-  100% {
-    opacity: 1;
-  }
-  50% {
-    opacity: 0;
-  }
-}
-
-/* Streaming message cursor — step-end produces a hard terminal-style blink (DS §7 Streaming state) */
-.streaming-cursor {
-  animation: blink-cursor 1s step-end infinite;
-}
-
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -68,8 +68,11 @@ async function parseJson<R>(res: Response): Promise<APIResponse<R>> {
   try {
     return JSON.parse(text) as APIResponse<R>;
   } catch {
-    // For 500s with non-JSON bodies, surface the raw response so the real
-    // error is visible rather than a generic "server unavailable" message.
+    // Non-JSON body — surface the real content, tag-stripped and truncated.
+    // A reverse proxy can emit an HTML page below 500 too (e.g. nginx 413 when
+    // an upload exceeds client_max_body_size), so the preview must be used on
+    // both branches; passing raw `text` through put a whole HTML document in a
+    // toast.
     const preview = text
       .replace(/<[^>]*>/g, " ")
       .replace(/\s+/g, " ")
@@ -77,12 +80,9 @@ async function parseJson<R>(res: Response): Promise<APIResponse<R>> {
       .slice(0, 300);
     throw new ApiError({
       code: "NETWORK_ERROR",
-      message:
-        res.status >= 500
-          ? preview
-            ? `Server error (${res.status}): ${preview}`
-            : "Server is unavailable. Please try again later."
-          : text,
+      message: preview
+        ? `Server error (${res.status}): ${preview}`
+        : "Server is unavailable. Please try again later.",
     });
   }
 }
@@ -90,6 +90,9 @@ async function parseJson<R>(res: Response): Promise<APIResponse<R>> {
 export async function request<T>(
   path: string,
   opts: RequestInit & { timeoutMs?: number } = {},
+  // Internal: set on the single retry after a token refresh so a repeat 401
+  // can't trigger an endless refresh→retry loop.
+  alreadyRefreshed = false,
 ): Promise<T> {
   const url = `${API_V1}${path}`;
   const isFormData = opts.body instanceof FormData;
@@ -97,10 +100,22 @@ export async function request<T>(
 
   const { timeoutMs, ...fetchOpts } = opts;
   const controller = new AbortController();
-  const timer = timeoutMs ? setTimeout(() => controller.abort(), timeoutMs) : null;
-  // Merge caller-supplied signal with our timeout signal
+  let timedOut = false;
+  const timer = timeoutMs
+    ? setTimeout(() => {
+        timedOut = true;
+        controller.abort();
+      }, timeoutMs)
+    : null;
+  // Merge caller-supplied signal with our timeout signal. An already-aborted
+  // signal never fires the listener, so honour it up front instead of issuing a
+  // request the caller has already cancelled.
   if (opts.signal) {
-    opts.signal.addEventListener("abort", () => controller.abort());
+    if (opts.signal.aborted) {
+      if (timer) clearTimeout(timer);
+      throw new ApiError({ code: "NETWORK_ERROR", message: "Request was cancelled." });
+    }
+    opts.signal.addEventListener("abort", () => controller.abort(), { once: true });
   }
 
   let res: Response;
@@ -115,7 +130,9 @@ export async function request<T>(
     if (err instanceof DOMException && err.name === "AbortError") {
       throw new ApiError({
         code: "NETWORK_ERROR",
-        message: "Request timed out — the server is taking too long to respond.",
+        message: timedOut
+          ? "Request timed out — the server is taking too long to respond."
+          : "Request was cancelled.",
       });
     }
     throw new ApiError({
@@ -132,24 +149,39 @@ export async function request<T>(
 
   if (res.status === 401) {
     const body = await parseJson<null>(res);
-    if (body.error?.code === "TOKEN_EXPIRED") {
+    if (body.error?.code === "TOKEN_EXPIRED" && !alreadyRefreshed) {
       await refreshAccessToken();
-      const retryHeaders = isFormData ? authHeadersNoContentType() : authHeaders();
-      const retry = await fetch(url, { ...opts, headers: { ...retryHeaders, ...opts.headers } });
-      if (retry.status === 429) {
-        handleRateLimit(retry);
-        throw new ApiError({ code: "RATE_LIMITED", message: "Rate limited" });
-      }
-      const retryBody = await parseJson<T>(retry);
-      if (retryBody.error) throw new ApiError(retryBody.error);
-      return retryBody.data as T;
+      // Retry once through the full request path so the retry gets its own
+      // timeout, abort handling, rate-limit/204 checks, and envelope parsing —
+      // rather than a hand-rolled fetch that silently drops the timeout.
+      return request<T>(path, opts, true);
     }
     if (body.error) throw new ApiError(body.error);
     throw new Error("Unauthorized");
   }
 
+  // 204 No Content (e.g. DELETE /mcp/servers/{name}) has an empty body — no
+  // envelope to parse. Return undefined rather than choking parseJson on "".
+  if (res.status === 204) return undefined as T;
+
   const body = await parseJson<T>(res);
   if (body.error) throw new ApiError(body.error);
+  // Only 429/401/204 are checked above; every other non-2xx used to fall through
+  // as a successful `undefined` whenever the body lacked an `error` key. That
+  // happens for any response that doesn't reach the envelope-wrapping handler —
+  // FastAPI emits `{"detail": ...}` for unmatched routes (404), wrong verbs (405)
+  // and request validation (422) — so a 404 was indistinguishable from an empty
+  // result, and destructive mutations reported success without doing anything.
+  if (!res.ok) {
+    const detail = (body as unknown as { detail?: unknown }).detail;
+    throw new ApiError({
+      code: `HTTP_${res.status}`,
+      message:
+        typeof detail === "string" && detail
+          ? detail
+          : res.statusText || `Request failed (${res.status})`,
+    });
+  }
   return body.data as T;
 }
 

--- a/src/lib/api/types/common.ts
+++ b/src/lib/api/types/common.ts
@@ -33,16 +33,30 @@ export class ApiError extends Error {
     this.details = error.details;
   }
 
-  /** Extract field-level validation errors when code is VALIDATION_ERROR. */
+  /**
+   * Extract field-level validation errors when code is VALIDATION_ERROR.
+   *
+   * The backend nests errors for nested models — `config.max_steps` arrives as
+   * `{ config: { max_steps: [...] } }`. Those are flattened to dotted keys
+   * ("config.max_steps"); a non-recursive read would drop them silently.
+   */
   getFieldErrors(): Record<string, string[]> {
     const result: Record<string, string[]> = {};
     const fields = (this.details as ValidationDetails | null)?.fields;
     if (!fields) return result;
-    for (const [name, errs] of Object.entries(fields)) {
-      if (Array.isArray(errs)) {
-        result[name] = errs.map((e) => e.message);
+
+    const walk = (node: unknown, path: string): void => {
+      if (Array.isArray(node)) {
+        result[path] = (node as FieldError[]).map((e) => e.message);
+        return;
       }
-    }
+      if (node && typeof node === "object") {
+        for (const [key, value] of Object.entries(node as Record<string, unknown>)) {
+          walk(value, path ? `${path}.${key}` : key);
+        }
+      }
+    };
+    walk(fields, "");
     return result;
   }
 }

--- a/src/lib/api/types/config.ts
+++ b/src/lib/api/types/config.ts
@@ -1,6 +1,12 @@
+/** Provider types this UI has first-class handling (labels, default models) for. */
+export type KnownProviderType = "openai" | "ollama" | "anthropic" | "google";
+
 export interface ProviderOut {
   name: string;
-  type: "openai" | "ollama" | "anthropic" | "google";
+  /** Open string on the wire — the backend field is a plain `str`, so a response
+   *  may carry a provider type this UI version doesn't know. Narrow with a
+   *  `in PROVIDER_LABELS` check before using it as a `KnownProviderType`. */
+  type: KnownProviderType | (string & {});
   base_url: string | null;
   has_api_key: boolean;
 }
@@ -17,7 +23,8 @@ export interface ProviderHealthOut {
 export interface ProviderCreateRequest {
   /** Unique alias: 1–64 chars, pattern ^[a-zA-Z0-9][a-zA-Z0-9_-]*$ */
   name: string;
-  type: "openai" | "ollama" | "anthropic" | "google";
+  /** Deliberately narrow on the request side — we only create providers this UI supports. */
+  type: KnownProviderType;
   base_url?: string | null;
   api_key?: string | null;
 }

--- a/src/lib/api/types/websocket.ts
+++ b/src/lib/api/types/websocket.ts
@@ -3,6 +3,7 @@ import type { ToolConfirmAction } from "./message";
 
 export type ServerMessageType =
   | "token"
+  | "discard_pending"
   | "tool_start"
   | "tool_end"
   | "tool_confirm_request"

--- a/src/lib/api/ws/log-socket.ts
+++ b/src/lib/api/ws/log-socket.ts
@@ -12,12 +12,24 @@ export interface LogSocketHandlers {
 }
 
 const PING_INTERVAL_MS = 30_000;
+// The server answers every ping with a pong and drops connections silent for 90 s,
+// so no INBOUND frame at all for this long means the socket is half-dead (server
+// vanished without a close frame, or the token expired mid-stream). Keyed on any
+// inbound frame rather than on log lines — a quiet log is perfectly normal and
+// must not be mistaken for a dead connection.
+const LIVENESS_TIMEOUT_MS = 90_000;
+// If the upgrade never completes (server accepts TCP but never upgrades) no
+// event fires at all, so status would stay "connecting" forever — and the UI
+// disables its only control in that state, leaving no way to cancel or retry.
+const CONNECT_TIMEOUT_MS = 10_000;
 
 // No reconnect logic — log streaming is stateless and user-controlled via the UI connect button.
 export class LogSocket {
   private ws: WebSocket | null = null;
   private pingTimer: ReturnType<typeof setInterval> | null = null;
   private errorOccurred = false;
+  private lastInboundAt = 0;
+  private connectTimer: ReturnType<typeof setTimeout> | null = null;
 
   constructor(private readonly handlers: LogSocketHandlers) {}
 
@@ -33,8 +45,19 @@ export class LogSocket {
     const url = `${WS_V1}/logs?token=${encodeURIComponent(token)}&level=${level}`;
     this.ws = new WebSocket(url);
 
+    this.connectTimer = setTimeout(() => {
+      this.connectTimer = null;
+      this.handleDeadConnection();
+    }, CONNECT_TIMEOUT_MS);
+
     this.ws.onopen = () => {
+      this.clearConnectTimer();
+      this.lastInboundAt = Date.now();
       this.pingTimer = setInterval(() => {
+        if (Date.now() - this.lastInboundAt > LIVENESS_TIMEOUT_MS) {
+          this.handleDeadConnection();
+          return;
+        }
         if (this.ws?.readyState === WebSocket.OPEN) {
           this.ws.send("ping");
         }
@@ -43,6 +66,8 @@ export class LogSocket {
     };
 
     this.ws.onmessage = (event: MessageEvent<string>) => {
+      // Any inbound frame (log_line or pong) proves the connection is alive.
+      this.lastInboundAt = Date.now();
       try {
         const raw = JSON.parse(event.data) as Record<string, unknown>;
         if (raw.type !== "log_line") return;
@@ -80,6 +105,7 @@ export class LogSocket {
 
   disconnect(): void {
     this.clearPingTimer();
+    this.clearConnectTimer();
     if (this.ws) {
       this.ws.onopen = null;
       this.ws.onmessage = null;
@@ -87,6 +113,31 @@ export class LogSocket {
       this.ws.onerror = null;
       this.ws.close(1000);
       this.ws = null;
+    }
+  }
+
+  /** Tear down a socket that stopped answering and surface it as an error, so the
+   *  viewer doesn't sit on a "connected" status that will never produce a line. */
+  private handleDeadConnection(): void {
+    this.clearPingTimer();
+    this.clearConnectTimer();
+    const ws = this.ws;
+    this.ws = null;
+    if (ws) {
+      ws.onopen = null;
+      ws.onmessage = null;
+      ws.onclose = null;
+      ws.onerror = null;
+      ws.close(1000);
+    }
+    this.errorOccurred = false;
+    this.handlers.onError();
+  }
+
+  private clearConnectTimer(): void {
+    if (this.connectTimer) {
+      clearTimeout(this.connectTimer);
+      this.connectTimer = null;
     }
   }
 

--- a/src/lib/api/ws/session-socket.test.ts
+++ b/src/lib/api/ws/session-socket.test.ts
@@ -10,14 +10,16 @@ class MockWebSocket {
 
   readyState = MockWebSocket.CONNECTING;
   url: string;
+  protocols: string | string[] | undefined;
   onopen: ((event: Event) => void) | null = null;
   onclose: ((event: CloseEvent) => void) | null = null;
   onmessage: ((event: MessageEvent) => void) | null = null;
   onerror: ((event: Event) => void) | null = null;
   sentMessages: string[] = [];
 
-  constructor(url: string) {
+  constructor(url: string, protocols?: string | string[]) {
     this.url = url;
+    this.protocols = protocols;
   }
 
   send(data: string) {
@@ -54,8 +56,8 @@ beforeAll(() => {
   vi.stubGlobal(
     "WebSocket",
     class extends MockWebSocket {
-      constructor(url: string) {
-        super(url);
+      constructor(url: string, protocols?: string | string[]) {
+        super(url, protocols);
         trackWebSocket(this);
       }
     },
@@ -115,7 +117,7 @@ describe("SessionSocket", () => {
     expect(lastCreatedWs).toBeNull();
   });
 
-  it("connects with token and session id in URL", () => {
+  it("connects with the session id in the URL and the token as a subprotocol", () => {
     const handlers = createHandlers();
     const socket = new SessionSocket("session-1", handlers);
 
@@ -123,7 +125,10 @@ describe("SessionSocket", () => {
 
     expect(lastCreatedWs).not.toBeNull();
     expect(lastCreatedWs!.url).toContain("session-1");
-    expect(lastCreatedWs!.url).toContain("token=test-token");
+    // The token travels via Sec-WebSocket-Protocol (["bearer", <jwt>]), not the
+    // query string — keeps the JWT out of URLs, logs, and browser history.
+    expect(lastCreatedWs!.url).not.toContain("token=");
+    expect(lastCreatedWs!.protocols).toEqual(["bearer", "test-token"]);
   });
 
   it("calls onOpen when connection opens", () => {

--- a/src/lib/api/ws/session-socket.ts
+++ b/src/lib/api/ws/session-socket.ts
@@ -18,6 +18,10 @@ import type { AgentState } from "../types/session";
 
 export interface SessionSocketHandlers {
   onToken: (text: string, isFinal: boolean) => void;
+  /** Server discarded the in-progress final answer (opt-in stream_final_answer);
+   *  the client must clear its streaming buffer. Optional — only fired when the
+   *  server sends a `discard_pending` frame. */
+  onDiscardPending?: () => void;
   onToolStart: (tool: string, toolCallId: string, input: Record<string, unknown>) => void;
   onToolEnd: (tool: string, toolCallId: string, durationMs: number, error: string | null) => void;
   onToolConfirmRequest: (payload: ToolConfirmRequestPayload) => void;
@@ -42,6 +46,7 @@ const HEALTH_POLL_INTERVAL_MS = 5_000;
 
 const VALID_SERVER_MESSAGE_TYPES: readonly string[] = [
   "token",
+  "discard_pending",
   "tool_start",
   "tool_end",
   "tool_confirm_request",
@@ -61,6 +66,7 @@ export class SessionSocket {
   private healthPollTimer: ReturnType<typeof setInterval> | null = null;
   private intentionallyClosed = false;
   private reconnectAttempts = 0;
+  private healthProbeInFlight = false;
 
   constructor(
     private readonly sessionId: string,
@@ -76,8 +82,15 @@ export class SessionSocket {
       return;
     }
 
-    const url = `${WS_V1}/sessions/${this.sessionId}?token=${encodeURIComponent(token)}&last_seq=${this._lastSeq}`;
-    this.ws = new WebSocket(url);
+    // Tear down any existing socket first. connect() is re-entrant (two health
+    // probes can resolve in the same tick, or a reconnect can race a manual
+    // connect); without this the previous socket is orphaned — its ping timer
+    // reference is overwritten so it can never be cleared, and its handlers keep
+    // writing into the shared streaming store.
+    this.teardownSocket();
+
+    const url = `${WS_V1}/sessions/${this.sessionId}?last_seq=${this._lastSeq}`;
+    this.ws = new WebSocket(url, ["bearer", token]);
 
     this.ws.onopen = () => {
       this.reconnectAttempts = 0;
@@ -94,30 +107,45 @@ export class SessionSocket {
       } catch {
         return; // Malformed message — ignore
       }
+      // Seq tracking runs BEFORE the type check so an unrecognised but
+      // seq-bearing frame (e.g. a server message type this client version
+      // doesn't know) still consumes its sequence slot. Dropping it before
+      // advancing _lastSeq would leave the counter stale, making the next
+      // frame look like a forward gap and triggering a needless
+      // close/reconnect loop.
+      if (typeof msg.seq === "number") {
+        if (this._lastSeq >= 0) {
+          if (msg.seq <= this._lastSeq) {
+            // Already-processed message (replay deduplication) — backend resends
+            // from last_seq inclusive on reconnect, so skip without closing.
+            return;
+          }
+          if (msg.seq !== this._lastSeq + 1) {
+            // True forward gap — close and reconnect so the server replays from
+            // last_seq. Do NOT update _lastSeq so replay starts from the correct
+            // position.
+            this.ws?.close();
+            return;
+          }
+        }
+        this._lastSeq = msg.seq;
+      }
       if (!VALID_SERVER_MESSAGE_TYPES.includes(msg.type as string)) {
-        return; // Unknown type — ignore to guard against spoofed/unexpected messages
+        // Unknown type — its seq slot is already consumed above; nothing to route.
+        return;
       }
-      if (this._lastSeq >= 0) {
-        if (msg.seq <= this._lastSeq) {
-          // Already-processed message (replay deduplication) — backend resends
-          // from last_seq inclusive on reconnect, so skip without closing.
-          return;
-        }
-        if (msg.seq !== this._lastSeq + 1) {
-          // True forward gap — close and reconnect so the server replays from
-          // last_seq. Do NOT update _lastSeq so replay starts from the correct
-          // position.
-          this.ws?.close();
-          return;
-        }
-      }
-      this._lastSeq = msg.seq;
       this.routeMessage(msg);
     };
 
     this.ws.onclose = (event: CloseEvent) => {
       this.clearPingTimer();
       if (this.intentionallyClosed) return;
+
+      // Publish the generic "disconnected" status FIRST: the branches below set
+      // more specific statuses (reconnecting / server-restarting) and running
+      // this afterwards would immediately overwrite them with "closed", so the
+      // user never saw the reconnecting indicator during a recoverable drop.
+      this.handlers.onDisconnect();
 
       switch (event.code) {
         case 4000:
@@ -143,8 +171,6 @@ export class SessionSocket {
           this.scheduleReconnect();
           break;
       }
-
-      this.handlers.onDisconnect();
     };
 
     this.ws.onerror = () => {
@@ -155,10 +181,26 @@ export class SessionSocket {
   disconnect(): void {
     this.intentionallyClosed = true;
     this.clearReconnectTimer();
-    this.clearPingTimer();
     this.clearHealthPoll();
-    this.ws?.close(1000);
+    this.teardownSocket();
+  }
+
+  /** Detach handlers BEFORE closing, then drop the socket. Frames already sitting
+   *  in the receive buffer are still dispatched during the closing handshake, and
+   *  the handlers write into a single global streaming store that isn't keyed by
+   *  session — so a closing socket could otherwise inject the previous session's
+   *  tokens into the one the user just opened. */
+  private teardownSocket(): void {
+    this.clearPingTimer();
+    const ws = this.ws;
     this.ws = null;
+    if (ws) {
+      ws.onopen = null;
+      ws.onmessage = null;
+      ws.onclose = null;
+      ws.onerror = null;
+      ws.close(1000);
+    }
   }
 
   sendMessage(text: string, mode: "normal" | "think" | "delegate" = "normal"): void {
@@ -166,8 +208,15 @@ export class SessionSocket {
     this.send({ type: "user_message", payload: payload as unknown as Record<string, unknown> });
   }
 
-  confirmTool(confirmationId: string, action: ToolConfirmPayload["action"]): void {
-    this.send({ type: "tool_confirm", payload: { confirmation_id: confirmationId, action } });
+  /** @returns false when the socket wasn't OPEN, so the caller can keep the
+   *  confirmation prompt open instead of pretending the answer was delivered.
+   *  The frame is NOT recoverable on reconnect — _lastSeq has already advanced
+   *  past the tool_confirm_request, so the server replay won't re-send it. */
+  confirmTool(confirmationId: string, action: ToolConfirmPayload["action"]): boolean {
+    return this.send({
+      type: "tool_confirm",
+      payload: { confirmation_id: confirmationId, action },
+    });
   }
 
   cancel(): void {
@@ -182,10 +231,13 @@ export class SessionSocket {
     return this._lastSeq;
   }
 
-  private send(msg: ClientMessage): void {
+  /** @returns false when the socket wasn't OPEN and the frame was dropped. */
+  private send(msg: ClientMessage): boolean {
     if (this.ws?.readyState === WebSocket.OPEN) {
       this.ws.send(JSON.stringify(msg));
+      return true;
     }
+    return false;
   }
 
   private routeMessage(msg: ServerMessage): void {
@@ -195,6 +247,9 @@ export class SessionSocket {
         this.handlers.onToken(p.text, p.final);
         break;
       }
+      case "discard_pending":
+        this.handlers.onDiscardPending?.();
+        break;
       case "tool_start": {
         const p = msg.payload as ToolStartPayload;
         this.handlers.onToolStart(p.tool_name, p.tool_call_id, p.input);
@@ -232,12 +287,25 @@ export class SessionSocket {
     if (!this.checkHealth) return;
     this.clearHealthPoll();
     this.healthPollTimer = setInterval(() => {
-      void this.checkHealth!().then((healthy) => {
-        if (healthy) {
-          this.clearHealthPoll();
-          this.connect();
-        }
-      });
+      // The probe has no timeout, so it can outlive the poll interval. Without
+      // this guard several stack up while the backend boots and then all resolve
+      // together, each calling connect().
+      if (this.healthProbeInFlight) return;
+      this.healthProbeInFlight = true;
+      void this.checkHealth!()
+        .then((healthy) => {
+          // disconnect() cannot cancel an in-flight probe, so re-check here —
+          // otherwise a probe resolving after teardown resurrects a socket for a
+          // session the user already left, with nothing left to close it.
+          if (this.intentionallyClosed) return;
+          if (healthy) {
+            this.clearHealthPoll();
+            this.connect();
+          }
+        })
+        .finally(() => {
+          this.healthProbeInFlight = false;
+        });
     }, HEALTH_POLL_INTERVAL_MS);
   }
 

--- a/src/lib/query-client.ts
+++ b/src/lib/query-client.ts
@@ -1,0 +1,19 @@
+import { QueryClient } from "@tanstack/react-query";
+
+/**
+ * The app-wide QueryClient.
+ *
+ * Lives in its own module (rather than in `main.tsx`) so non-React code — the
+ * auth store in particular — can clear the cache on sign-in/sign-out without
+ * importing the app entry point and creating a circular dependency.
+ */
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: 1,
+      refetchOnWindowFocus: false,
+      staleTime: 30_000,
+      gcTime: 5 * 60_000,
+    },
+  },
+});

--- a/src/lib/stores/auth-store.test.ts
+++ b/src/lib/stores/auth-store.test.ts
@@ -1,6 +1,6 @@
 import { vi, type Mock } from "vitest";
 import { useAuthStore } from "./auth-store";
-import { clearTokens, getAccessToken, getRefreshToken } from "../api/tokens";
+import { clearTokens, getAccessToken, getRefreshToken, setTokens } from "../api/tokens";
 import { act } from "@testing-library/react";
 
 vi.mock("sonner", () => ({
@@ -197,6 +197,14 @@ describe("auth store", () => {
 
   it("logout clears state even if API call fails", async () => {
     useAuthStore.setState({ isAuthenticated: true, user: { id: "u1" } as never });
+    // logout only calls the API when a refresh token exists (the backend requires
+    // it in the request body), so seed one to exercise the failing-API path.
+    setTokens({
+      access_token: "acc",
+      refresh_token: "ref",
+      token_type: "bearer",
+      expires_in: 3600,
+    });
 
     mockFetch.mockResolvedValueOnce(apiError("INTERNAL_ERROR", "Server error", 500));
 
@@ -210,6 +218,24 @@ describe("auth store", () => {
 
     expect(getStore().isAuthenticated).toBe(false);
     expect(getStore().user).toBeNull();
+  });
+
+  it("logout sends the refresh token so the server can revoke the session", async () => {
+    useAuthStore.setState({ isAuthenticated: true, user: { id: "u1" } as never });
+    setTokens({
+      access_token: "acc",
+      refresh_token: "ref",
+      token_type: "bearer",
+      expires_in: 3600,
+    });
+    mockFetch.mockResolvedValueOnce(apiResponse(null));
+
+    await act(async () => {
+      await getStore().logout();
+    });
+
+    const [, init] = mockFetch.mock.calls[mockFetch.mock.calls.length - 1] as [string, RequestInit];
+    expect(JSON.parse(init.body as string)).toEqual({ refresh_token: "ref" });
   });
 
   it("resets isLoading after login completes", async () => {

--- a/src/lib/stores/auth-store.ts
+++ b/src/lib/stores/auth-store.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import { api } from "../api/client";
-import { setTokens, clearTokens } from "../api/tokens";
+import { setTokens, clearTokens, getRefreshToken } from "../api/tokens";
+import { queryClient } from "../query-client";
 import type { TokenPair, UserOut } from "../api/types";
 
 interface AuthState {
@@ -22,6 +23,10 @@ export const useAuthStore = create<AuthState>((set) => ({
 
   login: async (username, password) => {
     set({ isLoading: true });
+    // Also clear here, not just on logout: a session can end without logout()
+    // running (expired refresh token redirecting to /login), and that path would
+    // otherwise leave the previous user's cache intact.
+    queryClient.clear();
     try {
       const tokens = await api.post<TokenPair>("/auth/login", { username, password });
       setTokens(tokens);
@@ -46,10 +51,17 @@ export const useAuthStore = create<AuthState>((set) => ({
 
   logout: async () => {
     try {
-      await api.post("/auth/logout");
+      // Backend requires the refresh token in the body so it can revoke the
+      // server-side session; a bodyless POST 422s and leaves the token valid.
+      const refresh_token = getRefreshToken();
+      if (refresh_token) await api.post("/auth/logout", { refresh_token });
     } finally {
       clearTokens();
       set({ user: null, isAuthenticated: false, isAdmin: false });
+      // Sessions/config/providers/models are cached with a 5-minute staleTime and
+      // gcTime, so without this the next user to sign in on this tab is served
+      // the previous user's data immediately and without a refetch.
+      queryClient.clear();
     }
   },
 }));

--- a/src/lib/stores/log-viewer-store.ts
+++ b/src/lib/stores/log-viewer-store.ts
@@ -4,9 +4,22 @@ import type { LogLinePayload } from "@/lib/api/types/system";
 
 export interface LogEntry extends LogLinePayload {
   key: number;
+  /** Timestamp formatted once at append time, so rows don't re-parse a Date on
+   *  every render of the (up to 500-row) list under a busy stream. */
+  displayTime: string;
 }
 
 export const MAX_LOG_LINES = 500;
+
+function formatLogTime(raw: string): string {
+  const d = new Date(raw.replace(",", "."));
+  if (!isNaN(d.getTime())) return d.toLocaleTimeString("en-US", { hour12: false });
+  const epoch = Number(raw);
+  if (!isNaN(epoch) && epoch > 1e9) {
+    return new Date(epoch * 1000).toLocaleTimeString("en-US", { hour12: false });
+  }
+  return raw;
+}
 
 export type LogConnectionStatus = "disconnected" | "connecting" | "connected" | "error";
 
@@ -15,8 +28,13 @@ interface LogViewerState {
   lines: LogEntry[];
   nextLineKey: number;
   connectionStatus: LogConnectionStatus;
+  /** True once the user has explicitly disconnected. The viewer unmounts when its
+   *  tab is switched away, so this must live in the store for that intent to
+   *  survive a remount and not be undone by auto-connect. */
+  userDisconnected: boolean;
   setLevel: (level: LogLevel) => void;
   setConnectionStatus: (status: LogConnectionStatus) => void;
+  setUserDisconnected: (value: boolean) => void;
   appendLine: (payload: LogLinePayload) => void;
   clearLines: () => void;
 }
@@ -26,14 +44,21 @@ export const useLogViewerStore = create<LogViewerState>((set) => ({
   lines: [],
   nextLineKey: 0,
   connectionStatus: "disconnected",
+  userDisconnected: false,
 
   setLevel: (level) => set({ level }),
 
   setConnectionStatus: (status) => set({ connectionStatus: status }),
 
+  setUserDisconnected: (value) => set({ userDisconnected: value }),
+
   appendLine: (payload) => {
     set((state) => {
-      const entry: LogEntry = { ...payload, key: state.nextLineKey };
+      const entry: LogEntry = {
+        ...payload,
+        key: state.nextLineKey,
+        displayTime: formatLogTime(payload.timestamp),
+      };
       const next = [...state.lines, entry];
       return {
         lines: next.length > MAX_LOG_LINES ? next.slice(next.length - MAX_LOG_LINES) : next,

--- a/src/lib/stores/streaming-store.ts
+++ b/src/lib/stores/streaming-store.ts
@@ -105,7 +105,7 @@ export const useStreamingStore = create<StreamingState>((set) => ({
         durationMs: null,
       };
       const prevLog = state.statusLog.length >= 100 ? state.statusLog.slice(-99) : state.statusLog;
-      return { toolActivities: next, hasActiveTool: true, statusLog: [...prevLog, entry] };
+      return { toolActivities: next, hasActiveTool: true, statusLog: [...prevLog, entry], streamingBuffer: "" };
     }),
 
   updateToolEnd: (toolCallId, durationMs, error) =>

--- a/src/lib/stores/streaming-store.ts
+++ b/src/lib/stores/streaming-store.ts
@@ -5,7 +5,12 @@ import type { MessageMode } from "@/lib/api/types/message";
 export type { ToolActivity };
 
 export interface StatusEntry {
+  /** Unique per log entry (React key). NOT the tool_call_id: the same
+   *  tool_call_id can legitimately arrive twice (provider retry, or a
+   *  tool_start replayed on a fresh socket whose _lastSeq reset to -1). */
   id: string;
+  /** The invocation this entry belongs to; matched by updateToolEnd. */
+  toolCallId: string;
   timestamp: number;
   tool: string;
   done: boolean;
@@ -34,6 +39,9 @@ interface StreamingState {
   setConnectionStatus: (status: StreamingState["connectionStatus"]) => void;
   setCurrentMode: (mode: MessageMode | null) => void;
   clearStatusLog: () => void;
+  /** Drop the in-progress streamed answer without touching tool/agent state —
+   *  used when the server sends `discard_pending` (regenerated final answer). */
+  clearStreamingBuffer: () => void;
   reset: () => void;
 }
 
@@ -49,6 +57,8 @@ const initialState = {
 
 let pendingTokens = "";
 let rafId: ReturnType<typeof requestAnimationFrame> | null = null;
+/** Monotonic suffix so repeated tool_call_ids still get unique React keys. */
+let statusEntrySeq = 0;
 
 function flushTokens() {
   rafId = null;
@@ -85,6 +95,14 @@ export const useStreamingStore = create<StreamingState>((set) => ({
 
   addToolStart: (tool, toolCallId, input) =>
     set((state) => {
+      // Discard any pre-tool reasoning: clearing streamingBuffer isn't enough —
+      // a scheduled RAF flush would otherwise resurrect buffered pendingTokens
+      // into the post-tool answer bubble.
+      if (rafId !== null) {
+        cancelAnimationFrame(rafId);
+        rafId = null;
+      }
+      pendingTokens = "";
       const next = new Map(state.toolActivities);
       const now = Date.now();
       next.set(toolCallId, {
@@ -97,7 +115,8 @@ export const useStreamingStore = create<StreamingState>((set) => ({
         done: false,
       });
       const entry: StatusEntry = {
-        id: toolCallId,
+        id: `${toolCallId}-${(statusEntrySeq += 1)}`,
+        toolCallId,
         timestamp: now,
         tool,
         done: false,
@@ -105,7 +124,12 @@ export const useStreamingStore = create<StreamingState>((set) => ({
         durationMs: null,
       };
       const prevLog = state.statusLog.length >= 100 ? state.statusLog.slice(-99) : state.statusLog;
-      return { toolActivities: next, hasActiveTool: true, statusLog: [...prevLog, entry], streamingBuffer: "" };
+      return {
+        toolActivities: next,
+        hasActiveTool: true,
+        statusLog: [...prevLog, entry],
+        streamingBuffer: "",
+      };
     }),
 
   updateToolEnd: (toolCallId, durationMs, error) =>
@@ -121,9 +145,23 @@ export const useStreamingStore = create<StreamingState>((set) => ({
           break;
         }
       }
-      const statusLog = state.statusLog.map((e) =>
-        e.id === toolCallId ? { ...e, done: true, error, durationMs } : e,
-      );
+      // Settle only the most recent un-done entry for this invocation. Matching
+      // every entry with the id would mark a repeated tool_call_id's earlier
+      // entry done too, overwriting its real duration.
+      let target = -1;
+      for (let i = state.statusLog.length - 1; i >= 0; i--) {
+        const entry = state.statusLog[i];
+        if (entry && entry.toolCallId === toolCallId && !entry.done) {
+          target = i;
+          break;
+        }
+      }
+      const statusLog =
+        target === -1
+          ? state.statusLog
+          : state.statusLog.map((e, i) =>
+              i === target ? { ...e, done: true, error, durationMs } : e,
+            );
       return { toolActivities: next, hasActiveTool, statusLog };
     }),
 
@@ -132,6 +170,15 @@ export const useStreamingStore = create<StreamingState>((set) => ({
   setCurrentMode: (mode) => set({ currentMode: mode }),
 
   clearStatusLog: () => set({ statusLog: [] }),
+
+  clearStreamingBuffer: () => {
+    if (rafId !== null) {
+      cancelAnimationFrame(rafId);
+      rafId = null;
+    }
+    pendingTokens = "";
+    set({ streamingBuffer: "" });
+  },
 
   reset: () => {
     if (rafId !== null) {
@@ -143,6 +190,14 @@ export const useStreamingStore = create<StreamingState>((set) => ({
       ...initialState,
       toolActivities: new Map<string, ToolActivity>(),
       connectionStatus: state.connectionStatus,
+      // Settle any tool still marked running: it never received a tool_end
+      // (turn was cancelled, errored, or timed out), so StatusBar would show a
+      // perpetual "running" spinner. Keep the persisted history, just finalize it.
+      statusLog: state.statusLog.some((e) => !e.done)
+        ? state.statusLog.map((e) =>
+            e.done ? e : { ...e, done: true, error: e.error ?? "aborted" },
+          )
+        : state.statusLog,
     }));
   },
 }));

--- a/src/lib/stores/wizard-store.ts
+++ b/src/lib/stores/wizard-store.ts
@@ -1,0 +1,37 @@
+import { create } from "zustand";
+import type { WizardStepOut } from "@/lib/api/types/config";
+
+export type WizardState = "idle" | "active" | "complete" | "error";
+
+/**
+ * Setup-wizard progress.
+ *
+ * The wizard lives inside a Radix TabsContent that unmounts when the admin
+ * switches Settings tabs. Holding progress in local useState therefore lost the
+ * whole run (and orphaned the server-side wizard, whose id lives in `step`) on
+ * any tab switch. Keeping it in a store lets progress survive the remount —
+ * same fix pattern as log-viewer-store's `userDisconnected`. Transient bits
+ * (slowHint) and re-derivable bits (the step-0 llmForm) stay local to the
+ * component.
+ */
+interface WizardStore {
+  wizardState: WizardState;
+  step: WizardStepOut | null;
+  answer: string;
+  errorMessage: string | null;
+  setWizardState: (state: WizardState) => void;
+  setStep: (step: WizardStepOut | null) => void;
+  setAnswer: (answer: string) => void;
+  setErrorMessage: (message: string | null) => void;
+}
+
+export const useWizardStore = create<WizardStore>((set) => ({
+  wizardState: "idle",
+  step: null,
+  answer: "",
+  errorMessage: null,
+  setWizardState: (wizardState) => set({ wizardState }),
+  setStep: (step) => set({ step }),
+  setAnswer: (answer) => set({ answer }),
+  setErrorMessage: (errorMessage) => set({ errorMessage }),
+}));

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -5,6 +5,20 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
+/**
+ * Parse a server timestamp as UTC.
+ *
+ * ES2016+ parses a date-TIME string with no offset (`2026-07-24T12:00:00`) as
+ * LOCAL time, while a date-only string is UTC. The backend can emit naive UTC
+ * timestamps, so parsing them raw shifts every value by the viewer's offset —
+ * west of UTC that makes recent items appear in the future, which relative-time
+ * formatters then render as "just now" indefinitely.
+ */
+export function parseServerDate(iso: string): Date {
+  const hasOffset = iso.endsWith("Z") || /[+-]\d{2}:\d{2}$/.test(iso);
+  return new Date(hasOffset ? iso : iso + "Z");
+}
+
 export function formatUptime(seconds: number): string {
   const d = Math.floor(seconds / 86400);
   const h = Math.floor((seconds % 86400) / 3600);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,22 +1,12 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter } from "react-router-dom";
 import { TooltipProvider } from "./components/ui/tooltip";
 import { App } from "./App";
 import { Toaster } from "./components/Toaster";
+import { queryClient } from "./lib/query-client";
 import "./index.css";
-
-const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      retry: 1,
-      refetchOnWindowFocus: false,
-      staleTime: 30_000,
-      gcTime: 5 * 60_000,
-    },
-  },
-});
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>

--- a/src/pages/admin/LiveLogViewer.tsx
+++ b/src/pages/admin/LiveLogViewer.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from "react";
+import { memo, useCallback, useEffect, useRef } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
@@ -18,7 +18,7 @@ import { api } from "@/lib/api/client";
 import { keys } from "@/lib/api/keys";
 import { useConfigQuery } from "@/hooks/shared/useConfigQuery";
 import type { LogLevel } from "@/lib/api/ws/log-socket";
-import { useLogViewerStore, MAX_LOG_LINES } from "@/lib/stores/log-viewer-store";
+import { useLogViewerStore, MAX_LOG_LINES, type LogEntry } from "@/lib/stores/log-viewer-store";
 import type { LogConnectionStatus } from "@/lib/stores/log-viewer-store";
 import { useLogSocket } from "@/hooks/admin/useLogSocket";
 
@@ -30,19 +30,6 @@ const LEVEL_BADGE_CLASSES: Record<LogLevel, string> = {
   CRITICAL: "bg-red-100 text-red-900 border-red-300",
 };
 
-function formatTimestamp(raw: string): string {
-  const normalized = raw.replace(",", ".");
-  const d = new Date(normalized);
-  if (!isNaN(d.getTime())) {
-    return d.toLocaleTimeString("en-US", { hour12: false });
-  }
-  const epoch = Number(raw);
-  if (!isNaN(epoch) && epoch > 1e9) {
-    return new Date(epoch * 1000).toLocaleTimeString("en-US", { hour12: false });
-  }
-  return raw;
-}
-
 function LogLevelBadge({ level }: { level: string }) {
   const cls = LEVEL_BADGE_CLASSES[level as LogLevel] ?? "bg-zinc-100 text-zinc-600";
   return (
@@ -51,6 +38,19 @@ function LogLevelBadge({ level }: { level: string }) {
     </Badge>
   );
 }
+
+// Memoized so appending one line doesn't re-render (and re-format) all 500 rows
+// under a busy stream. `line` is a stable object once appended.
+const LogRow = memo(function LogRow({ line }: { line: LogEntry }) {
+  return (
+    <div className="flex items-start gap-2 py-0.5">
+      <span className="shrink-0 text-zinc-500">{line.displayTime}</span>
+      <LogLevelBadge level={line.level} />
+      <span className="shrink-0 text-zinc-500">{line.logger}</span>
+      <span className="min-w-0 break-all text-zinc-900">{line.message}</span>
+    </div>
+  );
+});
 
 function connBadgeClass(status: LogConnectionStatus): string {
   if (status === "connected") return "bg-green-50 text-green-700 border-green-200";
@@ -66,10 +66,15 @@ export function LiveLogViewer() {
 
   const level = useLogViewerStore((s) => s.level);
   const storeSetLevel = useLogViewerStore((s) => s.setLevel);
+  const userDisconnected = useLogViewerStore((s) => s.userDisconnected);
+  const setUserDisconnected = useLogViewerStore((s) => s.setUserDisconnected);
   const { connect, disconnect } = useLogSocket();
 
   useEffect(() => {
-    if (connState === "disconnected") {
+    // This component unmounts whenever the admin switches tabs, so auto-connect
+    // must not undo an explicit Disconnect — `userDisconnected` carries that
+    // intent across remounts.
+    if (connState === "disconnected" && !userDisconnected) {
       connect(level);
     }
     return () => {
@@ -82,9 +87,14 @@ export function LiveLogViewer() {
   const queryClient = useQueryClient();
   const debugMutation = useMutation({
     mutationFn: (enabled: boolean) =>
-      api.post("/system/debug", { debug: enabled, verbose: enabled || null }),
+      // `verbose` must be a real boolean: the backend only writes cfg.verbose when
+      // the field is non-null, so sending null on disable left verbose logging on.
+      api.post("/system/debug", { debug: enabled, verbose: enabled }),
     onSuccess: (_data, enabled) => {
       void queryClient.invalidateQueries({ queryKey: keys.config() });
+      // SystemInfoOut reports debug/verbose too, and the System tab is served
+      // from cache on switch — without this it shows the pre-toggle state.
+      void queryClient.invalidateQueries({ queryKey: keys.systemInfo() });
       toast.success(enabled ? "Debug + verbose logging enabled" : "Debug logging disabled");
     },
     onError: () => {
@@ -112,7 +122,10 @@ export function LiveLogViewer() {
     (newLevel: string) => {
       const lvl = newLevel as LogLevel;
       storeSetLevel(lvl);
-      if (connState === "connected") {
+      // Also reconnect while "connecting": the socket is already being opened at
+      // the previous level, so skipping here would stream that level while the
+      // Select shows the new one.
+      if (connState === "connected" || connState === "connecting") {
         connect(lvl);
       }
     },
@@ -121,11 +134,13 @@ export function LiveLogViewer() {
 
   const handleToggleConnection = useCallback(() => {
     if (connState === "connected" || connState === "connecting") {
+      setUserDisconnected(true);
       disconnect();
     } else {
+      setUserDisconnected(false);
       connect(level);
     }
-  }, [connState, disconnect, connect, level]);
+  }, [connState, disconnect, connect, level, setUserDisconnected]);
 
   const connectionLabel =
     connState === "connected"
@@ -216,14 +231,7 @@ export function LiveLogViewer() {
                     : "Click Connect to start streaming logs."}
             </p>
           ) : (
-            lines.map((line) => (
-              <div key={line.key} className="flex items-start gap-2 py-0.5">
-                <span className="shrink-0 text-zinc-500">{formatTimestamp(line.timestamp)}</span>
-                <LogLevelBadge level={line.level} />
-                <span className="shrink-0 text-zinc-500">{line.logger}</span>
-                <span className="min-w-0 break-all text-zinc-900">{line.message}</span>
-              </div>
-            ))
+            lines.map((line) => <LogRow key={line.key} line={line} />)
           )}
         </div>
         {lines.length === MAX_LOG_LINES && (

--- a/src/pages/admin/UserManagementPanel.tsx
+++ b/src/pages/admin/UserManagementPanel.tsx
@@ -1,3 +1,4 @@
+import { parseServerDate } from "@/lib/utils";
 import { useState, type FormEvent } from "react";
 import { useQueryClient, useMutation } from "@tanstack/react-query";
 import { toast } from "sonner";
@@ -46,7 +47,7 @@ import {
 import { ConfirmDialog } from "@/components/ConfirmDialog";
 
 function formatDate(dateStr: string): string {
-  return new Date(dateStr).toLocaleDateString();
+  return parseServerDate(dateStr).toLocaleDateString();
 }
 
 interface RoleBadgeProps {
@@ -301,7 +302,7 @@ export function UserManagementPanel() {
     );
   }
 
-  if (isError) {
+  if (isError && !users) {
     return (
       <div className="flex flex-col items-center gap-3 py-12 text-center">
         <AlertTriangle className="h-12 w-12 text-red-600" strokeWidth={1.5} />

--- a/src/pages/assistant/AssistantChatList.tsx
+++ b/src/pages/assistant/AssistantChatList.tsx
@@ -1,3 +1,4 @@
+import { parseServerDate } from "@/lib/utils";
 import { useState, useEffect, useRef } from "react";
 import { AlertTriangle, Lock, MessageSquare } from "lucide-react";
 import { useAssistantChatsQuery } from "@/hooks/assistant/useAssistantChatsQuery";
@@ -23,7 +24,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { ChatHistoryDrawer } from "./ChatHistoryDrawer";
 
 function formatAbsoluteTime(isoString: string): string {
-  const d = new Date(isoString);
+  const d = parseServerDate(isoString);
   return d.toLocaleDateString() + " " + d.toLocaleTimeString();
 }
 
@@ -60,6 +61,13 @@ export function AssistantChatList() {
   const { playInboundChat } = useSound();
   // Track session keys seen in previous polls; null means not yet initialised (skip first population)
   const seenChatKeysRef = useRef<Set<string> | null>(null);
+
+  // Changing the filter loads a different chat set, so the previous filter's keys
+  // are not a valid baseline — re-prime on the next load instead of treating the
+  // new filter's chats as newly-arrived (which played a spurious inbound sound).
+  useEffect(() => {
+    seenChatKeysRef.current = null;
+  }, [channelFilter]);
 
   useEffect(() => {
     if (!chats) return;
@@ -113,7 +121,7 @@ export function AssistantChatList() {
         </div>
       </div>
 
-      {isError ? (
+      {isError && !chats ? (
         <div className="flex flex-col items-center gap-3 py-16 text-center">
           <AlertTriangle className="h-12 w-12 text-red-600" strokeWidth={1.5} />
           <p className="text-sm text-red-600">Failed to load chats.</p>

--- a/src/pages/assistant/CampaignsPanel.tsx
+++ b/src/pages/assistant/CampaignsPanel.tsx
@@ -1,3 +1,4 @@
+import { parseServerDate } from "@/lib/utils";
 import { useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
@@ -66,7 +67,7 @@ import { Textarea } from "@/components/ui/textarea";
 // ---------------------------------------------------------------------------
 
 function formatDate(iso: string): string {
-  return new Date(iso).toLocaleString(undefined, {
+  return parseServerDate(iso).toLocaleString(undefined, {
     month: "short",
     day: "numeric",
     hour: "2-digit",
@@ -194,14 +195,28 @@ function CreateCampaignDialog({ open, onOpenChange, onCreated }: CreateDialogPro
       goal: form.goal.trim(),
       instructions: form.instructions.trim(),
       targets,
-      max_follow_ups: parseInt(form.maxFollowUps, 10) || 3,
-      follow_up_interval_hours: parseInt(form.followUpIntervalHours, 10) || 24,
+      // `|| 3` would silently rewrite a deliberate 0 (initial message, no
+      // follow-ups) to 3 — fall back only when the field isn't a number.
+      max_follow_ups: Number.isNaN(parseInt(form.maxFollowUps, 10))
+        ? 3
+        : parseInt(form.maxFollowUps, 10),
+      follow_up_interval_hours: Number.isNaN(parseInt(form.followUpIntervalHours, 10))
+        ? 24
+        : parseInt(form.followUpIntervalHours, 10),
       auto_launch: form.autoLaunch,
     });
   }
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        // Reset on close so an abandoned draft doesn't reappear (one click from
+        // being submitted) the next time the dialog is opened.
+        if (!next) setForm(EMPTY_FORM);
+        onOpenChange(next);
+      }}
+    >
       <DialogContent className="max-w-lg">
         <DialogHeader>
           <DialogTitle>Create Campaign</DialogTitle>
@@ -781,7 +796,7 @@ export function CampaignsPanel() {
           </Select>
         </div>
 
-        {isError ? (
+        {isError && !data ? (
           <div className="flex flex-col items-center gap-3 py-16 text-center">
             <AlertTriangle className="h-12 w-12 text-red-600" strokeWidth={1.5} />
             <p className="text-sm text-red-600">Failed to load campaigns.</p>

--- a/src/pages/assistant/ChatHistoryDrawer.tsx
+++ b/src/pages/assistant/ChatHistoryDrawer.tsx
@@ -27,7 +27,7 @@ export function ChatHistoryDrawer({ chatKey, displayName, onClose }: ChatHistory
                 <Skeleton className="h-10 w-full" />
               </div>
             ))
-          ) : isError ? (
+          ) : isError && !messages ? (
             <div className="flex flex-col items-center gap-3 py-8 text-center">
               <AlertTriangle className="h-12 w-12 text-red-600" strokeWidth={1.5} />
               <p className="text-sm text-red-600">Failed to load chat history.</p>

--- a/src/pages/assistant/ContactList.tsx
+++ b/src/pages/assistant/ContactList.tsx
@@ -60,7 +60,7 @@ function ChannelIcon({ channel }: { channel: string }) {
 export function ContactList() {
   const { data: contacts, isLoading, isError, refetch } = useContactsQuery();
 
-  return isError ? (
+  return isError && !contacts ? (
     <div className="flex flex-col items-center gap-3 py-16 text-center">
       <AlertTriangle className="h-12 w-12 text-red-600" strokeWidth={1.5} />
       <p className="text-sm text-red-600">Failed to load contacts.</p>

--- a/src/pages/assistant/DeferredRecordTable.tsx
+++ b/src/pages/assistant/DeferredRecordTable.tsx
@@ -1,3 +1,4 @@
+import { parseServerDate } from "@/lib/utils";
 import { useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
@@ -30,7 +31,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
 
 function formatDateTime(isoString: string): string {
-  return new Date(isoString).toLocaleString(undefined, {
+  return parseServerDate(isoString).toLocaleString(undefined, {
     month: "short",
     day: "numeric",
     hour: "2-digit",
@@ -90,7 +91,7 @@ export function DeferredRecordTable() {
         </Select>
       </div>
 
-      {isError ? (
+      {isError && !deferred ? (
         <div className="flex flex-col items-center gap-3 py-16 text-center">
           <AlertTriangle className="h-12 w-12 text-red-600" strokeWidth={1.5} />
           <p className="text-sm text-red-600">Failed to load deferred records.</p>

--- a/src/pages/assistant/GuardrailsPanel.tsx
+++ b/src/pages/assistant/GuardrailsPanel.tsx
@@ -1,3 +1,4 @@
+import { parseServerDate } from "@/lib/utils";
 import { useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Trash2, ShieldOff, Ban } from "lucide-react";
@@ -22,7 +23,7 @@ import { useGuardrailsQuery } from "@/hooks/assistant/useGuardrailsQuery";
 
 function formatTimestamp(iso: string): string {
   try {
-    return new Date(iso).toLocaleString("en-US", {
+    return parseServerDate(iso).toLocaleString("en-US", {
       month: "short",
       day: "numeric",
       hour: "2-digit",
@@ -68,7 +69,7 @@ export function GuardrailsPanel() {
     );
   }
 
-  if (isError) {
+  if (isError && !data) {
     return (
       <div className="flex flex-col items-center gap-3 py-12 text-center">
         <p className="text-sm text-red-600">Failed to load guardrails data.</p>

--- a/src/pages/assistant/KnowledgePanel.tsx
+++ b/src/pages/assistant/KnowledgePanel.tsx
@@ -1,3 +1,4 @@
+import { parseServerDate } from "@/lib/utils";
 import { useEffect, useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
@@ -21,7 +22,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
 
 function formatDateTime(isoString: string): string {
-  return new Date(isoString).toLocaleString(undefined, {
+  return parseServerDate(isoString).toLocaleString(undefined, {
     month: "short",
     day: "numeric",
     year: "numeric",
@@ -146,7 +147,11 @@ export function KnowledgePanel({ isAdmin }: KnowledgePanelProps) {
     searchMutation.reset();
   }
 
-  const displayedFacts = searchMutation.data ?? facts;
+  // On a failed search `data` is undefined, which would silently fall back to the
+  // full list — visually identical to the un-searched state, so the user can't
+  // tell the search failed. Hold the table empty and surface it instead.
+  const searchFailed = searchMutation.isError;
+  const displayedFacts = searchFailed ? [] : (searchMutation.data ?? facts);
 
   return (
     <>
@@ -195,6 +200,12 @@ export function KnowledgePanel({ isAdmin }: KnowledgePanelProps) {
           {searchMutation.data.length} result{searchMutation.data.length !== 1 ? "s" : ""} for
           &ldquo;
           {searchQuery}&rdquo;
+        </p>
+      )}
+
+      {searchFailed && (
+        <p className="mb-3 text-sm text-red-600">
+          Search failed. Clear the search to return to the full knowledge base.
         </p>
       )}
 

--- a/src/pages/assistant/ScheduledMessageTable.tsx
+++ b/src/pages/assistant/ScheduledMessageTable.tsx
@@ -1,3 +1,4 @@
+import { parseServerDate } from "@/lib/utils";
 import { useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
@@ -49,7 +50,7 @@ function statusBadgeClass(status: string): string {
 }
 
 function formatDateTime(isoString: string): string {
-  return new Date(isoString).toLocaleString(undefined, {
+  return parseServerDate(isoString).toLocaleString(undefined, {
     month: "short",
     day: "numeric",
     hour: "2-digit",
@@ -59,16 +60,19 @@ function formatDateTime(isoString: string): string {
 
 /** Convert an ISO datetime string to the value format required by <input type="datetime-local">. */
 function isoToDatetimeLocal(isoString: string): string {
-  const d = new Date(isoString);
+  const d = parseServerDate(isoString);
   if (isNaN(d.getTime())) return "";
   // datetime-local format: YYYY-MM-DDTHH:mm
   const pad = (n: number) => String(n).padStart(2, "0");
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
 }
 
-/** Convert a datetime-local input value back to an ISO string in UTC. */
-function datetimeLocalToIso(value: string): string {
-  return new Date(value).toISOString();
+/** Convert a datetime-local input value back to an ISO string in UTC.
+ *  Returns undefined for an unparseable value — `toISOString()` throws a
+ *  RangeError on one, which would surface only as a generic "Failed to update". */
+function datetimeLocalToIso(value: string): string | undefined {
+  const d = new Date(value);
+  return isNaN(d.getTime()) ? undefined : d.toISOString();
 }
 
 export function ScheduledMessageTable() {
@@ -153,7 +157,7 @@ export function ScheduledMessageTable() {
         />
       </div>
 
-      {isError ? (
+      {isError && !scheduled ? (
         <div className="flex flex-col items-center gap-3 py-16 text-center">
           <AlertTriangle className="h-12 w-12 text-red-600" strokeWidth={1.5} />
           <p className="text-sm text-red-600">Failed to load scheduled messages.</p>

--- a/src/pages/assistant/SimulatorPanel.tsx
+++ b/src/pages/assistant/SimulatorPanel.tsx
@@ -1,9 +1,10 @@
 import { useState } from "react";
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import ReactMarkdown from "react-markdown";
 import { AlertTriangle, ChevronDown, Loader2 } from "lucide-react";
 import { api } from "@/lib/api/client";
+import { keys } from "@/lib/api/keys";
 import { ApiError } from "@/lib/api/types";
 import type { SimulateRequest, SimulateOut } from "@/lib/api/types";
 import { useAuthStore } from "@/lib/stores/auth-store";
@@ -30,6 +31,7 @@ import { Textarea } from "@/components/ui/textarea";
 
 export function SimulatorPanel() {
   const isAdmin = useAuthStore((s) => s.isAdmin);
+  const queryClient = useQueryClient();
 
   const [channel, setChannel] = useState<string>("whatsapp");
   const [direction, setDirection] = useState<"inbound" | "outbound">("inbound");
@@ -44,6 +46,16 @@ export function SimulatorPanel() {
 
   const simulateMutation = useMutation({
     mutationFn: (req: SimulateRequest) => api.post<SimulateOut>("/assistant/simulate", req),
+    onSuccess: (data) => {
+      // With "Persist memory" on, the simulation writes to live conversation
+      // memory — so the Chats tab and any open history drawer are now stale.
+      void queryClient.invalidateQueries({ queryKey: keys.assistant.chats() });
+      if (data.session_key) {
+        void queryClient.invalidateQueries({
+          queryKey: keys.assistant.chatMessages(data.session_key),
+        });
+      }
+    },
     onError: (err) => {
       if (err instanceof ApiError && err.code === "VALIDATION_ERROR") {
         const fields = err.getFieldErrors();
@@ -311,10 +323,13 @@ export function SimulatorPanel() {
               )}
             </div>
 
-            {/* Status badge row */}
+            {/* Status badge row. Each flag's on/off state is conveyed by color,
+                so it's mirrored into aria-label — otherwise all four read
+                identically to a screen reader regardless of what actually fired. */}
             <div className="flex flex-wrap gap-2 border-t border-zinc-200 pt-4">
               <Badge
                 variant="outline"
+                aria-label={`Guardrail blocked: ${data.blocked_by_guardrails ? "yes" : "no"}`}
                 className={
                   data.blocked_by_guardrails
                     ? "border-red-200 bg-red-50 text-red-700"
@@ -325,6 +340,7 @@ export function SimulatorPanel() {
               </Badge>
               <Badge
                 variant="outline"
+                aria-label={`Suppressed: ${data.suppressed ? "yes" : "no"}`}
                 className={
                   data.suppressed
                     ? "border-amber-200 bg-amber-50 text-amber-700"
@@ -335,6 +351,7 @@ export function SimulatorPanel() {
               </Badge>
               <Badge
                 variant="outline"
+                aria-label={`Deferred: ${data.deferred ? "yes" : "no"}`}
                 className={
                   data.deferred
                     ? "border-blue-200 bg-blue-50 text-blue-700"
@@ -345,6 +362,7 @@ export function SimulatorPanel() {
               </Badge>
               <Badge
                 variant="outline"
+                aria-label={`Memory persisted: ${data.memory_persisted ? "yes" : "no"}`}
                 className={
                   data.memory_persisted
                     ? "border-teal-200 bg-teal-50 text-teal-700"

--- a/src/pages/assistant/WorkflowsPanel.tsx
+++ b/src/pages/assistant/WorkflowsPanel.tsx
@@ -1,3 +1,4 @@
+import { parseServerDate } from "@/lib/utils";
 import { useState, type FormEvent, type ChangeEvent } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
@@ -78,7 +79,7 @@ import {
 // ---------------------------------------------------------------------------
 
 function formatDate(iso: string): string {
-  return new Date(iso).toLocaleDateString(undefined, {
+  return parseServerDate(iso).toLocaleDateString(undefined, {
     year: "numeric",
     month: "short",
     day: "numeric",
@@ -339,13 +340,12 @@ function WorkflowFormFields({
           </div>
 
           <div className="space-y-1.5">
-            <Label htmlFor="wf-confidence">Min confidence</Label>
+            <Label htmlFor="wf-confidence">Min keyword matches</Label>
             <Input
               id="wf-confidence"
               type="number"
-              min="0"
-              max="1"
-              step="0.01"
+              min="1"
+              step="1"
               value={form.min_confidence}
               onChange={(e: ChangeEvent<HTMLInputElement>) =>
                 onChange({ min_confidence: e.target.value })
@@ -403,7 +403,9 @@ function CreateWorkflowDialog({ open, onOpenChange, onSuccess }: CreateWorkflowD
         enabled: form.auto_detect_enabled,
         keywords: splitCsv(form.auto_detect_keywords),
         patterns: splitCsv(form.auto_detect_patterns),
-        min_confidence: parseFloat(form.min_confidence) || 1,
+        min_confidence: Number.isNaN(parseInt(form.min_confidence, 10))
+          ? 1
+          : parseInt(form.min_confidence, 10),
       },
     };
     createMutation.mutate(body);
@@ -499,7 +501,10 @@ function EditWorkflowDialog({ workflow, onOpenChange, onSuccess }: EditWorkflowD
     if (!workflow) return;
     const body: WorkflowUpdateRequest = {
       name: form.name.trim(),
-      description: form.description.trim() || undefined,
+      // null, not undefined — JSON.stringify drops undefined, so on this partial
+      // update clearing a workflow's description was a silent no-op that still
+      // reported success. (The create path may legitimately omit it.)
+      description: form.description.trim() || null,
       system_prompt: form.system_prompt.trim() || null,
       knowledge_base: form.knowledge_base,
       tool_policy: {
@@ -510,7 +515,9 @@ function EditWorkflowDialog({ workflow, onOpenChange, onSuccess }: EditWorkflowD
         enabled: form.auto_detect_enabled,
         keywords: splitCsv(form.auto_detect_keywords),
         patterns: splitCsv(form.auto_detect_patterns),
-        min_confidence: parseFloat(form.min_confidence) || 1,
+        min_confidence: Number.isNaN(parseInt(form.min_confidence, 10))
+          ? 1
+          : parseInt(form.min_confidence, 10),
       },
     };
     updateMutation.mutate({ id: workflow.id, body });
@@ -574,8 +581,12 @@ function DocumentsDialog({ workflowId, onOpenChange }: DocumentsDialogProps) {
       api.delete(
         `/assistant/workflows/${encodeURIComponent(wfId)}/documents/${encodeURIComponent(docId)}`,
       ),
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: keys.workflows.documents(workflowId!) });
+    onSuccess: (_data, { wfId }) => {
+      // Use the mutation's own wfId, not the workflowId prop: this dialog was
+      // mounted unconditionally, so closing it mid-request set the prop to null
+      // and the invalidate targeted keys.workflows.documents(null) — the real
+      // list stayed stale and the deleted doc reappeared on reopen.
+      void queryClient.invalidateQueries({ queryKey: keys.workflows.documents(wfId) });
       toast.success("Document deleted");
     },
     onError: (err) => {
@@ -592,8 +603,8 @@ function DocumentsDialog({ workflowId, onOpenChange }: DocumentsDialogProps) {
         `/assistant/workflows/${encodeURIComponent(wfId)}/documents`,
         formData,
       ),
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: keys.workflows.documents(workflowId!) });
+    onSuccess: (_data, { wfId }) => {
+      void queryClient.invalidateQueries({ queryKey: keys.workflows.documents(wfId) });
       toast.success("Document uploaded");
     },
     onError: (err) => {
@@ -651,7 +662,7 @@ function DocumentsDialog({ workflowId, onOpenChange }: DocumentsDialogProps) {
               />
             </div>
 
-            {isError ? (
+            {isError && !docs ? (
               <div className="flex flex-col items-center gap-3 py-12 text-center">
                 <AlertTriangle className="h-10 w-10 text-red-600" strokeWidth={1.5} />
                 <p className="text-sm text-red-600">Failed to load documents.</p>
@@ -1023,7 +1034,7 @@ export function WorkflowsPanel() {
           </div>
         )}
 
-        {isError ? (
+        {isError && !page ? (
           <div className="flex flex-col items-center gap-3 py-16 text-center">
             <AlertTriangle className="h-12 w-12 text-red-600" strokeWidth={1.5} />
             <p className="text-sm text-red-600">Failed to load workflows.</p>
@@ -1140,7 +1151,10 @@ export function WorkflowsPanel() {
         />
       )}
 
-      {isAdmin && (
+      {/* Mounted only while open so each open starts from the persisted workflow —
+          an always-mounted dialog keeps its form state, so edits abandoned via
+          Cancel would reappear (and silently re-save) on the next open. */}
+      {isAdmin && editTarget && (
         <EditWorkflowDialog
           workflow={editTarget}
           onOpenChange={(open) => !open && setEditTarget(null)}
@@ -1148,15 +1162,24 @@ export function WorkflowsPanel() {
         />
       )}
 
-      <DocumentsDialog
-        workflowId={docsWorkflowId}
-        onOpenChange={(open) => !open && setDocsWorkflowId(null)}
-      />
+      {/* Mounted only while open, like the sibling dialogs — otherwise its
+          deleteTarget state and the ConfirmDialog it renders survive the parent
+          closing, leaving a confirm dialog pointing at a now-null workflowId. */}
+      {docsWorkflowId && (
+        <DocumentsDialog
+          workflowId={docsWorkflowId}
+          onOpenChange={(open) => !open && setDocsWorkflowId(null)}
+        />
+      )}
 
-      <BindingsDialog
-        workflowId={bindingsWorkflowId}
-        onOpenChange={(open) => !open && setBindingsWorkflowId(null)}
-      />
+      {/* Mounted only while open — its bindings/chats queries would otherwise run
+          as soon as the Workflows tab renders, before any dialog is opened. */}
+      {bindingsWorkflowId && (
+        <BindingsDialog
+          workflowId={bindingsWorkflowId}
+          onOpenChange={(open) => !open && setBindingsWorkflowId(null)}
+        />
+      )}
 
       <ConfirmDialog
         open={deleteTarget !== null}

--- a/src/pages/chat/MessageBubble.tsx
+++ b/src/pages/chat/MessageBubble.tsx
@@ -148,6 +148,11 @@ export const MessageBubble = memo(function MessageBubble({ message }: MessageBub
       return <SystemBubble message={message} />;
     case "tool":
       return <ToolBubble message={message} />;
+    default:
+      // `role` is a closed union in TS but nothing validates the wire value, so
+      // a role added server-side would fall through and render nothing — the
+      // message would silently vanish from the transcript. Show it instead.
+      return <SystemBubble message={message} />;
   }
 });
 

--- a/src/pages/chat/MessageList.tsx
+++ b/src/pages/chat/MessageList.tsx
@@ -96,7 +96,12 @@ export function MessageList({
     );
   }
 
-  if (isError) {
+  // Only take over the pane when there is genuinely nothing to show. In v5
+  // `isError` is also true when a BACKGROUND refetch fails while cached data is
+  // still present — and useSessionSocket invalidates this query after every
+  // turn — so a bare `isError` check replaced an entire live conversation with
+  // an error screen, making the user think their history was lost.
+  if (isError && messages.length === 0) {
     return (
       <div className="flex flex-1 items-center justify-center">
         <div className="flex flex-col items-center gap-3">

--- a/src/pages/chat/SessionHeader.tsx
+++ b/src/pages/chat/SessionHeader.tsx
@@ -47,6 +47,7 @@ function ConnectionStatusDot({ status }: { status: string }) {
   return (
     <span
       className="flex items-center gap-1.5 text-xs text-zinc-500"
+      data-cy="connection-status"
       role="status"
       title={label}
       aria-label={label}
@@ -63,6 +64,7 @@ export function SessionHeader({ session }: SessionHeaderProps) {
   const [nameError, setNameError] = useState<string | null>(null);
   const [clearHistoryOpen, setClearHistoryOpen] = useState(false);
   const [keepLast, setKeepLast] = useState("0");
+  const [keepLastError, setKeepLastError] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const queryClient = useQueryClient();
 
@@ -101,6 +103,9 @@ export function SessionHeader({ session }: SessionHeaderProps) {
       api.patch<SessionOut>(`/sessions/${session.id}`, { config }),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: keys.sessions.detail(session.id) });
+      // sessions.list is a sibling key, not a child of detail — without this the
+      // session card on /sessions keeps showing the old model for up to 5 min.
+      void queryClient.invalidateQueries({ queryKey: keys.sessions.all });
       toast.success("Settings saved");
     },
     onError: (err) => {
@@ -129,8 +134,17 @@ export function SessionHeader({ session }: SessionHeaderProps) {
   }
 
   function handleClearHistoryConfirm() {
-    const n = parseInt(keepLast, 10);
-    clearHistoryMutation.mutate(isNaN(n) || n < 0 ? 0 : n);
+    // 0 means "delete everything", so an unparseable field must NOT fall back to
+    // it — clearing the input and confirming would irreversibly wipe the whole
+    // history. Number() (not parseInt) because <input type="number"> accepts
+    // exponent notation, and parseInt("1e2") silently yields 1.
+    const n = Number(keepLast);
+    if (!Number.isInteger(n) || n < 0) {
+      setKeepLastError("Enter a whole number of messages to keep (0 clears all).");
+      return;
+    }
+    setKeepLastError(null);
+    clearHistoryMutation.mutate(n);
   }
 
   function handleMemoryClick() {
@@ -162,6 +176,11 @@ export function SessionHeader({ session }: SessionHeaderProps) {
   }
 
   function commitEdit() {
+    // Wired to both Enter and onBlur. Disabling the focused input mid-flight
+    // makes the browser fire blur, which re-entered here and issued a second
+    // identical PATCH — the duplicate can come back SESSION_NAME_DUPLICATE and
+    // show a rename error for a rename that actually succeeded.
+    if (renameMutation.isPending) return;
     const trimmed = draftName.trim();
     if (!trimmed || trimmed === session.name) {
       setEditing(false);
@@ -316,10 +335,20 @@ export function SessionHeader({ session }: SessionHeaderProps) {
               min={0}
               step={1}
               value={keepLast}
-              onChange={(e) => setKeepLast(e.target.value)}
+              onChange={(e) => {
+                setKeepLast(e.target.value);
+                setKeepLastError(null);
+              }}
               disabled={clearHistoryMutation.isPending}
+              aria-invalid={keepLastError !== null}
+              aria-describedby={keepLastError ? "keep-last-error" : undefined}
               className="min-h-11 w-32"
             />
+            {keepLastError && (
+              <p id="keep-last-error" className="mt-1.5 text-sm text-red-600">
+                {keepLastError}
+              </p>
+            )}
           </div>
           <DialogFooter>
             <Button

--- a/src/pages/chat/SessionPage.tsx
+++ b/src/pages/chat/SessionPage.tsx
@@ -57,7 +57,11 @@ export function SessionPage() {
     // Only fire on transition — not on initial render or same-state renders
     if (prev === agentState) return;
     if (agentState === "idle") {
-      playResponseComplete();
+      // Chime only on a real completion: the agent passes through `done` before
+      // onDone resets to idle. A running-state → idle jump (navigating away from
+      // an in-flight session, or cancel) never goes through `done`, so it must
+      // not trigger the completion sound.
+      if (prev === "done") playResponseComplete();
     } else if (agentState === "error") {
       playError();
     }
@@ -93,7 +97,14 @@ export function SessionPage() {
   // tokens (tool call markup, pre-tool reasoning) may be in the buffer but they
   // are not the final response, so StreamingMessageBubble would show confusing content.
   // StreamingMessageBubble only appears for the final response phase (no active tools).
-  const streamingSlot = isAgentRunning ? (
+  // Keep the live slot mounted through the transient "done" state. The server
+  // sends agent_state:"done" as its own frame one tick BEFORE the "done" frame
+  // that commits the message to cache — so tearing down on !isAgentRunning here
+  // blanks the streamed answer for a frame until onDone's atomic read-then-reset
+  // runs. Gating on "done" too makes onDone (which sets state to idle) the single
+  // teardown point.
+  const showLiveSlot = isAgentRunning || agentState === "done";
+  const streamingSlot = showLiveSlot ? (
     hasActiveTool || !hasStreamingContent ? (
       <TypingIndicator mode={currentMode} />
     ) : (
@@ -107,7 +118,12 @@ export function SessionPage() {
       <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
         <SessionHeader session={session} />
 
+        {/* key by session: the route isn't keyed, so without this MessageList
+            never remounts when switching sessions and its one-shot
+            initial-scroll flag stays spent — landing the user on the OLDEST
+            message of every session after the first. */}
         <MessageList
+          key={sessionId}
           sessionId={sessionId}
           hasStreamingContent={hasStreamingContent}
           streamingSlot={streamingSlot}

--- a/src/pages/chat/SessionSettingsPopover.tsx
+++ b/src/pages/chat/SessionSettingsPopover.tsx
@@ -63,6 +63,7 @@ function isDirtyCheck(draft: DraftState, config: SessionConfig): boolean {
 export function SessionSettingsPopover({ session, onSave, isSaving }: SessionSettingsPopoverProps) {
   const [open, setOpen] = useState(false);
   const [draft, setDraft] = useState<DraftState>(() => draftFromConfig(session.config));
+  const [maxStepsError, setMaxStepsError] = useState<string | null>(null);
 
   const isMobile = useMediaQuery("(max-width: 1023px)");
   const modelsQuery = useModelsQuery({ staleTime: 5 * 60_000 });
@@ -71,11 +72,20 @@ export function SessionSettingsPopover({ session, onSave, isSaving }: SessionSet
 
   async function handleSave() {
     const systemPrompt = draft.systemPrompt?.trim() || null;
-    const maxStepsRaw = draft.maxSteps !== "" ? parseInt(draft.maxSteps, 10) : null;
-    const maxSteps =
-      maxStepsRaw !== null && !isNaN(maxStepsRaw) && maxStepsRaw >= 1 && maxStepsRaw <= 200
-        ? maxStepsRaw
-        : null;
+    // Number(), not parseInt(): <input type="number"> accepts exponent notation
+    // and parseInt("1e3") silently yields 1. An out-of-range value must block the
+    // save rather than collapse to null — null means "reset to the global
+    // default", so the old code discarded the entry and still toasted success.
+    const maxStepsRaw = draft.maxSteps !== "" ? Number(draft.maxSteps) : null;
+    if (
+      maxStepsRaw !== null &&
+      (!Number.isInteger(maxStepsRaw) || maxStepsRaw < 1 || maxStepsRaw > 200)
+    ) {
+      setMaxStepsError("Enter a whole number between 1 and 200, or leave blank for the default.");
+      return;
+    }
+    setMaxStepsError(null);
+    const maxSteps = maxStepsRaw;
     const contextCompression = draft.contextCompression;
 
     try {
@@ -175,13 +185,18 @@ export function SessionSettingsPopover({ session, onSave, isSaving }: SessionSet
                 min={1}
                 max={200}
                 value={draft.maxSteps}
-                onChange={(e) => setDraft((prev) => ({ ...prev, maxSteps: e.target.value }))}
+                onChange={(e) => {
+                  setDraft((prev) => ({ ...prev, maxSteps: e.target.value }));
+                  setMaxStepsError(null);
+                }}
                 placeholder="100"
                 className="w-24"
                 disabled={isSaving}
+                aria-invalid={maxStepsError !== null}
               />
               <span className="text-sm text-zinc-500">default: 100, max: 200</span>
             </div>
+            {maxStepsError && <p className="mt-1.5 text-sm text-red-600">{maxStepsError}</p>}
           </div>
 
           {/* Context compression */}

--- a/src/pages/chat/StreamingMessageBubble.tsx
+++ b/src/pages/chat/StreamingMessageBubble.tsx
@@ -46,11 +46,6 @@ export function StreamingMessageBubble() {
             >
               {streamingBuffer}
             </ReactMarkdown>
-            <span
-              className="streaming-cursor ml-0.5 inline-block h-4 w-0.5 bg-zinc-900 align-middle motion-reduce:hidden"
-              data-cy="streaming-cursor"
-              aria-hidden="true"
-            />
           </div>
         </div>
       </div>

--- a/src/pages/chat/StreamingMessageBubble.tsx
+++ b/src/pages/chat/StreamingMessageBubble.tsx
@@ -31,10 +31,11 @@ export function StreamingMessageBubble() {
     <div
       className="flex justify-start"
       ref={endRef}
-      role="status"
-      aria-live="polite"
-      aria-atomic="false"
-      aria-label="Assistant response"
+      data-cy="streaming-message"
+      // No aria-live here: ReactMarkdown rebuilds the subtree on every batched
+      // token, so a live region re-announced the growing message continuously.
+      // The settled MessageBubble provides a single announcement at turn end.
+      aria-hidden="true"
     >
       <div className="max-w-[75%]">
         <div className="rounded-2xl rounded-bl-sm border border-zinc-200 bg-white px-4 py-3 text-zinc-900 shadow-sm">

--- a/src/pages/chat/ToolConfirmationModal.tsx
+++ b/src/pages/chat/ToolConfirmationModal.tsx
@@ -58,6 +58,21 @@ export function ToolConfirmationModal({ onConfirm }: ToolConfirmationModalProps)
   const confirming =
     lastConfirmationId !== null && lastConfirmationId === pendingConfirmation?.confirmation_id;
 
+  // Clear the in-flight lock whenever the prompt opens, closes, or is replaced.
+  // The lock is an identity comparison that never expires on its own, so if the
+  // server re-issues the SAME confirmation_id — e.g. after a reconnect dropped
+  // the first answer — every button would render disabled on a dialog that
+  // blocks Escape and outside-click, leaving the app stuck until a page reload.
+  // Comparing against the last *seen* id (rather than only on open) also covers
+  // the close-then-reopen-same-id path.
+  const openedId = pendingConfirmation?.confirmation_id ?? null;
+  const [seenOpenId, setSeenOpenId] = useState<string | null>(null);
+  if (openedId !== seenOpenId) {
+    setSeenOpenId(openedId);
+    setLastConfirmationId(null);
+    setActiveAction(null);
+  }
+
   function handleAction(action: ToolConfirmPayload["action"]) {
     if (!pendingConfirmation || confirming) return;
     setLastConfirmationId(pendingConfirmation.confirmation_id);

--- a/src/pages/chat/ToolsSidebar.tsx
+++ b/src/pages/chat/ToolsSidebar.tsx
@@ -224,11 +224,15 @@ export function ToolsSidebar({ sessionId, asSheet = false }: ToolsSidebarProps) 
     },
   });
 
+  // Depend on the stable `.mutate`, not the whole mutation result (new object
+  // every render), so this callback's identity holds and the ToolRow memo keeps
+  // working while filtering.
+  const { mutate: mutateStatus } = statusMutation;
   const handleStatusChange = useCallback(
     (name: string, from: TriPosition, to: TriPosition, status: ToolStatus) => {
-      statusMutation.mutate(buildAction(name, from, to, status));
+      mutateStatus(buildAction(name, from, to, status));
     },
-    [statusMutation],
+    [mutateStatus],
   );
 
   const filtered = tools
@@ -265,7 +269,7 @@ export function ToolsSidebar({ sessionId, asSheet = false }: ToolsSidebarProps) 
 
   const toolList = (
     <div className="flex-1 overflow-y-auto">
-      {isError ? (
+      {isError && !tools ? (
         <div className="flex flex-col items-center gap-3 p-4 py-8 text-center">
           <p className="text-sm text-red-600">Failed to load tools.</p>
           <Button variant="outline" size="sm" onClick={() => void refetch()}>

--- a/src/pages/documents/DocumentCard.tsx
+++ b/src/pages/documents/DocumentCard.tsx
@@ -1,3 +1,4 @@
+import { parseServerDate } from "@/lib/utils";
 import { FileText, Trash2 } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -18,7 +19,7 @@ function formatFileSize(bytes: number): string {
 }
 
 function formatDate(iso: string): string {
-  return new Date(iso).toLocaleDateString(undefined, {
+  return parseServerDate(iso).toLocaleDateString(undefined, {
     year: "numeric",
     month: "short",
     day: "numeric",

--- a/src/pages/documents/DocumentUploadDialog.tsx
+++ b/src/pages/documents/DocumentUploadDialog.tsx
@@ -42,7 +42,10 @@ export function DocumentUploadDialog({ open, onOpenChange }: DocumentUploadDialo
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: keys.documents.list() });
       toast.success("Document uploaded successfully");
-      handleClose();
+      // Must NOT go through handleClose(): query-core dispatches the success
+      // state only AFTER running onSuccess, so `isPending` is still true here and
+      // handleClose's in-flight guard would swallow the close.
+      resetAndClose();
     },
     onError: (error) => {
       const message = error instanceof ApiError ? error.message : "Upload failed";
@@ -58,7 +61,11 @@ export function DocumentUploadDialog({ open, onOpenChange }: DocumentUploadDialo
       return;
     }
 
-    const ext = "." + file.name.split(".").pop()?.toLowerCase();
+    // `split(".").pop()` returns the whole filename when there is no dot, so a
+    // file literally named "pdf" was accepted as ".pdf" — and "Makefile" was
+    // rejected as ".makefile". Use the last dot, and only when it isn't leading.
+    const dot = file.name.lastIndexOf(".");
+    const ext = dot > 0 ? file.name.slice(dot).toLowerCase() : "";
     const isAcceptedType = ACCEPTED_TYPES.includes(ext) || ACCEPTED_MIME.includes(file.type);
     if (!isAcceptedType) {
       setValidationError("Only PDF, TXT, and Markdown files are accepted.");
@@ -100,12 +107,21 @@ export function DocumentUploadDialog({ open, onOpenChange }: DocumentUploadDialo
     uploadMutation.mutate(selectedFile);
   }
 
-  function handleClose() {
+  /** Unconditional teardown — safe to call from the mutation's own callbacks. */
+  function resetAndClose() {
     setSelectedFile(null);
     setValidationError(null);
     setDragOver(false);
     uploadMutation.reset();
     onOpenChange(false);
+  }
+
+  /** User-initiated dismissal (Escape / outside-click / Cancel). Escape and
+   *  outside-click route here too, so without this guard the dialog could be
+   *  dismissed mid-upload even though the Cancel button is disabled. */
+  function handleClose() {
+    if (uploadMutation.isPending) return;
+    resetAndClose();
   }
 
   const isUploading = uploadMutation.isPending;

--- a/src/pages/documents/index.tsx
+++ b/src/pages/documents/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { FileText, Upload } from "lucide-react";
 import { toast } from "sonner";
@@ -24,6 +24,14 @@ export function DocumentsPage() {
 
   const { data, isFetchingNextPage, hasNextPage, fetchNextPage, status, refetch } =
     useDocumentsQuery();
+
+  // Guard the sentinel: without the in-flight check a page whose fetch keeps
+  // failing re-fires on every intersection callback.
+  const handleIntersect = useCallback(() => {
+    if (hasNextPage && !isFetchingNextPage) {
+      void fetchNextPage();
+    }
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
 
   const deleteMutation = useMutation({
     mutationFn: (id: string) => api.delete(`/rag/documents/${id}`),
@@ -66,7 +74,7 @@ export function DocumentsPage() {
           </div>
         )}
 
-        {status === "error" && (
+        {status === "error" && documents.length === 0 && (
           <div className="flex flex-col items-center gap-3 py-12 text-center">
             <p className="text-sm text-red-600">Failed to load documents.</p>
             <Button variant="outline" size="sm" onClick={() => void refetch()}>
@@ -107,7 +115,7 @@ export function DocumentsPage() {
         )}
 
         {hasNextPage && (
-          <InfiniteScrollSentinel onIntersect={fetchNextPage} loading={isFetchingNextPage} />
+          <InfiniteScrollSentinel onIntersect={handleIntersect} loading={isFetchingNextPage} />
         )}
 
         {isAdmin && <DocumentUploadDialog open={uploadOpen} onOpenChange={setUploadOpen} />}

--- a/src/pages/layout/AppShell.tsx
+++ b/src/pages/layout/AppShell.tsx
@@ -58,8 +58,15 @@ export function AppShell() {
   const usernameInitial = user?.username.charAt(0).toUpperCase() ?? "?";
 
   async function handleSignOut() {
-    await logout();
-    navigate("/login");
+    // logout() clears tokens/state in a finally block but re-throws a failed
+    // /auth/logout. This is wired to an onClick (() => void), so the rejection
+    // would float AND skip the navigate — leaving the user on a protected page
+    // with no session.
+    try {
+      await logout();
+    } finally {
+      navigate("/login");
+    }
   }
 
   return (

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -95,9 +95,14 @@ function LoginForm() {
             disabled={isLoading}
             required
             aria-invalid={!!fieldErrors.username}
+            aria-describedby={fieldErrors.username ? "login-username-error" : undefined}
             className={fieldErrors.username ? "border-red-600" : ""}
           />
-          {fieldErrors.username && <p className="text-sm text-red-600">{fieldErrors.username}</p>}
+          {fieldErrors.username && (
+            <p id="login-username-error" className="text-sm text-red-600">
+              {fieldErrors.username}
+            </p>
+          )}
         </div>
 
         <div className="space-y-1.5">
@@ -113,9 +118,14 @@ function LoginForm() {
             disabled={isLoading}
             required
             aria-invalid={!!fieldErrors.password}
+            aria-describedby={fieldErrors.password ? "login-password-error" : undefined}
             className={fieldErrors.password ? "border-red-600" : ""}
           />
-          {fieldErrors.password && <p className="text-sm text-red-600">{fieldErrors.password}</p>}
+          {fieldErrors.password && (
+            <p id="login-password-error" className="text-sm text-red-600">
+              {fieldErrors.password}
+            </p>
+          )}
         </div>
 
         <Button type="submit" size="lg" disabled={isLoading} className="mt-6 w-full">
@@ -202,13 +212,17 @@ function RegisterForm() {
             maxLength={64}
             pattern="[a-zA-Z0-9_\-]+"
             aria-invalid={!!fieldErrors.username}
-            aria-describedby="username-hint"
+            aria-describedby={fieldErrors.username ? "reg-username-error" : "username-hint"}
             className={fieldErrors.username ? "border-red-600" : ""}
           />
           <p id="username-hint" className="text-xs text-zinc-500">
             3–64 characters: letters, digits, hyphens, underscores
           </p>
-          {fieldErrors.username && <p className="text-sm text-red-600">{fieldErrors.username}</p>}
+          {fieldErrors.username && (
+            <p id="reg-username-error" className="text-sm text-red-600">
+              {fieldErrors.username}
+            </p>
+          )}
         </div>
 
         <div className="space-y-1.5">
@@ -224,9 +238,14 @@ function RegisterForm() {
             disabled={isLoading}
             required
             aria-invalid={!!fieldErrors.email}
+            aria-describedby={fieldErrors.email ? "reg-email-error" : undefined}
             className={fieldErrors.email ? "border-red-600" : ""}
           />
-          {fieldErrors.email && <p className="text-sm text-red-600">{fieldErrors.email}</p>}
+          {fieldErrors.email && (
+            <p id="reg-email-error" className="text-sm text-red-600">
+              {fieldErrors.email}
+            </p>
+          )}
         </div>
 
         <div className="space-y-1.5">
@@ -244,13 +263,17 @@ function RegisterForm() {
             minLength={8}
             maxLength={128}
             aria-invalid={!!fieldErrors.password}
-            aria-describedby="password-hint"
+            aria-describedby={fieldErrors.password ? "reg-password-error" : "password-hint"}
             className={fieldErrors.password ? "border-red-600" : ""}
           />
           <p id="password-hint" className="text-xs text-zinc-500">
             8–128 characters, with uppercase, lowercase, digit, and special character
           </p>
-          {fieldErrors.password && <p className="text-sm text-red-600">{fieldErrors.password}</p>}
+          {fieldErrors.password && (
+            <p id="reg-password-error" className="text-sm text-red-600">
+              {fieldErrors.password}
+            </p>
+          )}
         </div>
 
         <Button type="submit" size="lg" disabled={isLoading} className="mt-6 w-full">

--- a/src/pages/sessions/NewSessionDialog.tsx
+++ b/src/pages/sessions/NewSessionDialog.tsx
@@ -88,9 +88,16 @@ export function NewSessionDialog({ triggerCy }: { triggerCy?: string } = {}) {
     const model = toApiValue(form.model);
     const memoryMode = toApiValue(form.memoryMode) as MemoryMode | undefined;
     const systemPrompt = form.systemPrompt.trim() || null;
-    const maxStepsRaw = parseInt(form.maxSteps, 10);
+    // Number(), not parseInt(): <input type="number"> accepts exponent notation
+    // and parseInt("1e3") silently yields 1.
+    const maxStepsRaw = Number(form.maxSteps);
     const maxSteps =
-      !isNaN(maxStepsRaw) && maxStepsRaw >= 1 && maxStepsRaw <= 200 ? maxStepsRaw : null;
+      form.maxSteps !== "" &&
+      Number.isInteger(maxStepsRaw) &&
+      maxStepsRaw >= 1 &&
+      maxStepsRaw <= 200
+        ? maxStepsRaw
+        : null;
     const contextCompression = form.contextCompression;
 
     const hasConfig =

--- a/src/pages/sessions/index.tsx
+++ b/src/pages/sessions/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo } from "react";
+import { useState, useCallback, useEffect, useMemo, useRef } from "react";
 import { useUIStore } from "@/lib/stores/ui-store";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
@@ -21,6 +21,18 @@ import { api } from "@/lib/api/client";
 import { keys } from "@/lib/api/keys";
 import { useSessionsQuery } from "@/hooks/shared/useSessionsQuery";
 import { cn } from "@/lib/utils";
+
+function reportBulkResult(results: PromiseSettledResult<unknown>[], total: number, verb: string) {
+  const failed = results.filter((r) => r.status === "rejected").length;
+  const ok = total - failed;
+  if (failed === 0) {
+    toast.success(`${ok} session${ok === 1 ? "" : "s"} ${verb}`);
+  } else if (ok === 0) {
+    toast.error(`Sessions could not be ${verb}`);
+  } else {
+    toast.warning(`${ok} ${verb}, ${failed} failed`);
+  }
+}
 
 function SessionCardSkeleton() {
   return (
@@ -113,33 +125,41 @@ export function SessionsPage() {
     },
   });
 
+  // Bulk ops use allSettled so a single failure doesn't abandon the successful
+  // deletes: always reconcile the cache and clear the selection, then report the
+  // real success/failure split.
   const bulkArchiveMutation = useMutation({
     mutationFn: (ids: string[]) =>
-      Promise.all(ids.map((id) => api.delete<null>(`/sessions/${id}`))),
-    onSuccess: (_data, ids) => {
+      Promise.allSettled(ids.map((id) => api.delete<null>(`/sessions/${id}`))),
+    onSuccess: (results, ids) => reportBulkResult(results, ids.length, "archived"),
+    onSettled: () => {
       void queryClient.invalidateQueries({ queryKey: keys.sessions.all });
       setSelectedIds(new Set());
-      toast.success(`${ids.length} session${ids.length === 1 ? "" : "s"} archived`);
-    },
-    onError: () => {
-      toast.error("Some sessions could not be archived");
     },
   });
 
   const bulkDeleteMutation = useMutation({
     mutationFn: (ids: string[]) =>
-      Promise.all(ids.map((id) => api.delete<null>(`/sessions/${id}?permanent=true`))),
-    onSuccess: (_data, ids) => {
+      Promise.allSettled(ids.map((id) => api.delete<null>(`/sessions/${id}?permanent=true`))),
+    onSuccess: (results, ids) => reportBulkResult(results, ids.length, "permanently deleted"),
+    onSettled: () => {
       void queryClient.invalidateQueries({ queryKey: keys.sessions.all });
       setSelectedIds(new Set());
-      toast.success(`${ids.length} session${ids.length === 1 ? "" : "s"} permanently deleted`);
-    },
-    onError: () => {
-      toast.error("Some sessions could not be deleted");
     },
   });
 
-  const handleDelete = useCallback((id: string, name: string) => setActionTarget({ id, name }), []);
+  // Stable id-only handler: the call sites previously wrapped this in an inline
+  // `(id) => handleDelete(id, s.name)` closure, giving every memoized card/row a
+  // fresh onDelete identity and re-rendering the whole list on each checkbox
+  // toggle. Read the name from a ref so the callback stays stable across renders.
+  const sessionsRef = useRef(sessions);
+  useEffect(() => {
+    sessionsRef.current = sessions;
+  }, [sessions]);
+  const handleDelete = useCallback((id: string) => {
+    const name = sessionsRef.current.find((s) => s.id === id)?.name ?? "";
+    setActionTarget({ id, name });
+  }, []);
 
   const handleUnarchive = useCallback(
     (id: string) => unarchiveMutation.mutate(id),
@@ -249,7 +269,7 @@ export function SessionsPage() {
                   <SessionCard
                     key={s.id}
                     session={s}
-                    onDelete={(id) => handleDelete(id, s.name)}
+                    onDelete={handleDelete}
                     onUnarchive={handleUnarchive}
                     models={models}
                     onEditModel={handleEditModel}
@@ -321,7 +341,7 @@ export function SessionsPage() {
                       <SessionRow
                         key={s.id}
                         session={s}
-                        onDelete={(id) => handleDelete(id, s.name)}
+                        onDelete={handleDelete}
                         onUnarchive={handleUnarchive}
                         models={models}
                         onEditModel={handleEditModel}

--- a/src/pages/settings/ApiKeyList.tsx
+++ b/src/pages/settings/ApiKeyList.tsx
@@ -1,3 +1,4 @@
+import { parseServerDate } from "@/lib/utils";
 import { useState, type FormEvent } from "react";
 import { useQueryClient, useMutation } from "@tanstack/react-query";
 import { toast } from "sonner";
@@ -30,7 +31,7 @@ import {
 
 function formatDate(dateStr: string | null): string {
   if (!dateStr) return "—";
-  return new Date(dateStr).toLocaleDateString(undefined, {
+  return parseServerDate(dateStr).toLocaleDateString(undefined, {
     year: "numeric",
     month: "short",
     day: "numeric",
@@ -45,9 +46,16 @@ function CreatedKeyDisplay({ apiKey }: CreatedKeyDisplayProps) {
   const [copied, setCopied] = useState(false);
 
   async function handleCopy() {
-    await navigator.clipboard.writeText(apiKey);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+    // This is the one and only time the key is shown, so a failed copy must be
+    // visible rather than an unhandled rejection that leaves the button silent.
+    try {
+      await navigator.clipboard.writeText(apiKey);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      setCopied(false);
+      toast.error("Couldn't copy — select the key and copy it manually.");
+    }
   }
 
   return (
@@ -102,7 +110,11 @@ function CreateKeyDialog({ onCreated }: CreateKeyDialogProps) {
     e.preventDefault();
     const body: APIKeyCreateRequest = {
       label: label.trim(),
-      expires_in_days: expiresInDays ? parseInt(expiresInDays, 10) : null,
+      // Number(), not parseInt(): <input type="number"> accepts exponent
+      // notation, and parseInt("1e3") yields 1 — a key meant to last ~3 years
+      // would silently expire tomorrow. Non-integers fall back to "never".
+      expires_in_days:
+        expiresInDays && Number.isInteger(Number(expiresInDays)) ? Number(expiresInDays) : null,
     };
     createMutation.mutate(body);
   }
@@ -277,7 +289,7 @@ export function ApiKeyList() {
     );
   }
 
-  if (isError) {
+  if (isError && !apiKeys) {
     return (
       <div className="flex flex-col items-center gap-3 py-12 text-center">
         <AlertTriangle className="h-12 w-12 text-red-600" strokeWidth={1.5} />

--- a/src/pages/settings/ConfigFlagsForm.tsx
+++ b/src/pages/settings/ConfigFlagsForm.tsx
@@ -56,7 +56,9 @@ const FLAG_ROWS: FlagRow[] = [
 export function ConfigFlagsForm() {
   const isAdmin = useAuthStore((s) => s.isAdmin);
   const queryClient = useQueryClient();
-  const { data: config, isLoading, isError, refetch } = useConfigQuery();
+  // No isError gate: `config` presence is the real signal — a failed background
+  // refetch must not blank a form that already has data to show.
+  const { data: config, isLoading, refetch } = useConfigQuery();
   const [pendingFlags, setPendingFlags] = useState<Set<ConfigBooleanKey>>(new Set());
 
   const soundEnabled = useUIStore((s) => s.soundEnabled);
@@ -66,16 +68,37 @@ export function ConfigFlagsForm() {
     mutationFn: (patch: ConfigPatchRequest) => api.patch("/config", patch),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: keys.config() });
+      // SystemInfoOut also reports debug/verbose, and SystemInfoCard remounts
+      // from cache on tab switch — so it would show the pre-toggle values.
+      void queryClient.invalidateQueries({ queryKey: keys.systemInfo() });
     },
     onError: () => {
       toast.error("Failed to update configuration");
+    },
+    // Clearing the pending flag must live at the mutation level, not in a
+    // per-call `mutate(vars, { onSettled })`: all five switches share this one
+    // observer, so a second toggle discards the first call's callbacks and the
+    // first switch would stay disabled until the page unmounts.
+    onSettled: (_data, _error, patch) => {
+      setPendingFlags((prev) => {
+        const next = new Set(prev);
+        for (const key of Object.keys(patch)) next.delete(key as ConfigBooleanKey);
+        return next;
+      });
     },
   });
 
   const reloadMutation = useMutation({
     mutationFn: () => api.post("/config/reload"),
     onSuccess: () => {
+      // Re-reading the config file can change providers, models, MCP servers and
+      // the reported system info — all cached for 5 min (60 s for system info),
+      // so invalidating only keys.config() left the other tabs stale.
       void queryClient.invalidateQueries({ queryKey: keys.config() });
+      void queryClient.invalidateQueries({ queryKey: keys.providers() });
+      void queryClient.invalidateQueries({ queryKey: keys.models() });
+      void queryClient.invalidateQueries({ queryKey: keys.mcpServers() });
+      void queryClient.invalidateQueries({ queryKey: keys.systemInfo() });
       toast.success("Configuration reloaded from disk");
     },
     onError: () => {
@@ -85,18 +108,7 @@ export function ConfigFlagsForm() {
 
   function handleToggle(flagKey: ConfigBooleanKey, value: boolean) {
     setPendingFlags((prev) => new Set(prev).add(flagKey));
-    patchMutation.mutate(
-      { [flagKey]: value },
-      {
-        onSettled: () => {
-          setPendingFlags((prev) => {
-            const next = new Set(prev);
-            next.delete(flagKey);
-            return next;
-          });
-        },
-      },
-    );
+    patchMutation.mutate({ [flagKey]: value });
   }
 
   if (isLoading) {
@@ -119,7 +131,7 @@ export function ConfigFlagsForm() {
     );
   }
 
-  if (isError || !config) {
+  if (!config) {
     return (
       <div className="flex flex-col items-center gap-3 py-12 text-center">
         <p className="text-sm text-red-600">Failed to load configuration.</p>

--- a/src/pages/settings/McpServerList.tsx
+++ b/src/pages/settings/McpServerList.tsx
@@ -1,3 +1,4 @@
+import { parseServerDate } from "@/lib/utils";
 import { useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
@@ -65,7 +66,7 @@ export function McpServerList() {
   const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
 
   const restartMutation = useMutation({
-    mutationFn: (name: string) => api.post(`/mcp/servers/${name}/restart`),
+    mutationFn: (name: string) => api.post(`/mcp/servers/${encodeURIComponent(name)}/restart`),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: keys.mcpServers() });
       toast.success("MCP server restarted");
@@ -76,7 +77,7 @@ export function McpServerList() {
   });
 
   const deleteMutation = useMutation({
-    mutationFn: (name: string) => api.delete(`/mcp/servers/${name}`),
+    mutationFn: (name: string) => api.delete(`/mcp/servers/${encodeURIComponent(name)}`),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: keys.mcpServers() });
       toast.success("MCP server removed");
@@ -99,7 +100,7 @@ export function McpServerList() {
     );
   }
 
-  if (isError) {
+  if (isError && !servers) {
     return (
       <div className="flex flex-col items-center gap-3 py-12 text-center">
         <AlertTriangle className="h-12 w-12 text-red-600" strokeWidth={1.5} />
@@ -164,7 +165,7 @@ export function McpServerList() {
                       <StatusBadge status={server.status} />
                       {server.connected_at != null && (
                         <p className="mt-0.5 text-xs text-zinc-500">
-                          {new Date(server.connected_at).toLocaleString()}
+                          {parseServerDate(server.connected_at).toLocaleString()}
                         </p>
                       )}
                       {server.error && (

--- a/src/pages/settings/ProviderList.tsx
+++ b/src/pages/settings/ProviderList.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { Fragment, useState } from "react";
 import { useQueryClient, useMutation } from "@tanstack/react-query";
 import { toast } from "sonner";
 import {
@@ -51,11 +51,7 @@ interface HealthResult {
   result: ProviderHealthOut | null;
 }
 
-interface ProviderListProps {
-  onRequestWizard?: () => void;
-}
-
-export function ProviderList({ onRequestWizard: _onRequestWizard }: ProviderListProps) {
+export function ProviderList() {
   const isAdmin = useAuthStore((s) => s.isAdmin);
   const queryClient = useQueryClient();
   const {
@@ -135,7 +131,7 @@ export function ProviderList({ onRequestWizard: _onRequestWizard }: ProviderList
       base_url?: string | null;
       api_key?: string | null;
     }) =>
-      api.patch<ProviderOut>(`/config/providers/${name}`, {
+      api.patch<ProviderOut>(`/config/providers/${encodeURIComponent(name)}`, {
         base_url: base_url || null,
         api_key: api_key || null,
       }),
@@ -150,7 +146,7 @@ export function ProviderList({ onRequestWizard: _onRequestWizard }: ProviderList
   });
 
   const deleteProviderMutation = useMutation({
-    mutationFn: (name: string) => api.delete<null>(`/config/providers/${name}`),
+    mutationFn: (name: string) => api.delete<null>(`/config/providers/${encodeURIComponent(name)}`),
     onSuccess: () => {
       invalidateProviderData();
       toast.success("Provider removed");
@@ -194,7 +190,8 @@ export function ProviderList({ onRequestWizard: _onRequestWizard }: ProviderList
   });
 
   const healthCheckMutation = useMutation({
-    mutationFn: (name: string) => api.post<ProviderHealthOut>(`/config/providers/${name}/health`),
+    mutationFn: (name: string) =>
+      api.post<ProviderHealthOut>(`/config/providers/${encodeURIComponent(name)}/health`),
     onSuccess: (result, name) => {
       setHealthResults((prev) => new Map(prev).set(name, { providerName: name, result }));
     },
@@ -225,7 +222,7 @@ export function ProviderList({ onRequestWizard: _onRequestWizard }: ProviderList
   const slugPattern = /^[a-zA-Z0-9][a-zA-Z0-9_-]*$/;
   const addProviderValid = newName.trim().length > 0 && slugPattern.test(newName.trim());
 
-  if (providersError || modelsError) {
+  if ((providersError && !providers) || (modelsError && !models)) {
     return (
       <div className="flex flex-col items-center gap-3 py-12 text-center">
         <p className="text-sm text-red-600">Failed to load provider data.</p>
@@ -301,8 +298,8 @@ export function ProviderList({ onRequestWizard: _onRequestWizard }: ProviderList
                   const isEditing = editingProvider === provider.name;
 
                   return (
-                    <>
-                      <TableRow key={provider.name} className="hover:bg-zinc-50">
+                    <Fragment key={provider.name}>
+                      <TableRow className="hover:bg-zinc-50">
                         <TableCell className="font-medium text-zinc-900">{provider.name}</TableCell>
                         <TableCell className="text-zinc-600">{provider.type}</TableCell>
                         <TableCell className="max-w-44 truncate font-mono text-sm text-zinc-600">
@@ -457,7 +454,12 @@ export function ProviderList({ onRequestWizard: _onRequestWizard }: ProviderList
                                       updateProviderMutation.mutate({
                                         name: provider.name,
                                         base_url: editBaseUrl || null,
-                                        api_key: editApiKey || null,
+                                        // Omit rather than send null when blank:
+                                        // the field promises "leave blank to keep
+                                        // current", but null is the backend's
+                                        // "clear the key" signal — so editing only
+                                        // the base URL would wipe the API key.
+                                        ...(editApiKey ? { api_key: editApiKey } : {}),
                                       })
                                     }
                                   >
@@ -473,7 +475,7 @@ export function ProviderList({ onRequestWizard: _onRequestWizard }: ProviderList
                           </TableCell>
                         </TableRow>
                       )}
-                    </>
+                    </Fragment>
                   );
                 })}
               </TableBody>
@@ -672,7 +674,11 @@ export function ProviderList({ onRequestWizard: _onRequestWizard }: ProviderList
                 {models.map((m) => {
                   const isSwitching =
                     switchModelMutation.isPending && switchModelMutation.variables === m.alias;
-                  const isClickable = isAdmin && !m.is_active;
+                  // Gate on the shared mutation, not just the clicked row:
+                  // otherwise a second row stays clickable during the first
+                  // switch and two concurrent POST /config/model calls race —
+                  // the one that lands last decides the global active model.
+                  const isClickable = isAdmin && !m.is_active && !switchModelMutation.isPending;
 
                   return (
                     <TableRow

--- a/src/pages/settings/SetupWizard.tsx
+++ b/src/pages/settings/SetupWizard.tsx
@@ -241,7 +241,7 @@ export function SetupWizard() {
 
   function handleReject() {
     if (!step) return;
-    advanceMutation.mutate({ wizardId: step.wizard_id, body: { data: { accept: false } } });
+    advanceMutation.mutate({ wizardId: step.wizard_id, body: { answer: "Please revise the configuration." } });
   }
 
   function handleCancel() {

--- a/src/pages/settings/SetupWizard.tsx
+++ b/src/pages/settings/SetupWizard.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from "react";
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { AlertTriangle, CheckCircle2, Loader2, Wand2, X } from "lucide-react";
 import ReactMarkdown from "react-markdown";
@@ -7,6 +7,8 @@ import { api } from "@/lib/api/client";
 import { ApiError } from "@/lib/api/types/common";
 import type { WizardStartRequest, WizardStepRequest, WizardStepOut } from "@/lib/api/types/config";
 import { useConfigQuery } from "@/hooks/shared/useConfigQuery";
+import { useWizardStore } from "@/lib/stores/wizard-store";
+import { keys } from "@/lib/api/keys";
 import {
   markdownComponents,
   REMARK_PLUGINS,
@@ -36,7 +38,6 @@ function stripProtocolLines(text: string): string {
     .trim();
 }
 
-type WizardState = "idle" | "active" | "complete" | "error";
 type ProviderType = "ollama" | "openai" | "anthropic" | "google";
 
 const PROVIDER_LABELS: Record<ProviderType, string> = {
@@ -69,13 +70,20 @@ interface LlmFormState {
 }
 
 export function SetupWizard() {
-  const [wizardState, setWizardState] = useState<WizardState>("idle");
-  const [step, setStep] = useState<WizardStepOut | null>(null);
-  const [answer, setAnswer] = useState("");
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  // Persisted in a store so the run survives the Radix tab unmount on tab switch.
+  const wizardState = useWizardStore((s) => s.wizardState);
+  const setWizardState = useWizardStore((s) => s.setWizardState);
+  const step = useWizardStore((s) => s.step);
+  const setStep = useWizardStore((s) => s.setStep);
+  const answer = useWizardStore((s) => s.answer);
+  const setAnswer = useWizardStore((s) => s.setAnswer);
+  const errorMessage = useWizardStore((s) => s.errorMessage);
+  const setErrorMessage = useWizardStore((s) => s.setErrorMessage);
   const [slowHint, setSlowHint] = useState(false);
   const slowHintTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const queryClient = useQueryClient();
 
   // Query current config to pre-fill Step 0 form
   const { data: currentConfig } = useConfigQuery({
@@ -93,13 +101,20 @@ export function SetupWizard() {
           ? (firstProvider.type as ProviderType)
           : "openai";
       const activeModel = currentConfig?.models.find((m) => m.is_active);
+      // Only adopt the active model when it actually belongs to this provider —
+      // otherwise we'd pre-fill e.g. provider "ollama" with an OpenAI model and
+      // the Step-0 connection probe would fail confusingly.
+      const modelForProvider =
+        activeModel && activeModel.provider === firstProvider.name
+          ? activeModel.model_name
+          : DEFAULT_MODELS[pt];
       return {
         providerType: pt,
         providerName: firstProvider.name,
         apiKey: "",
         hasExistingKey: firstProvider.has_api_key,
         baseUrl: firstProvider.base_url ?? "",
-        model: activeModel?.model_name ?? DEFAULT_MODELS[pt],
+        model: modelForProvider,
       };
     }
     return {
@@ -171,6 +186,12 @@ export function SetupWizard() {
       setAnswer("");
       if (data.complete) {
         setWizardState("complete");
+        // The wizard has persisted providers/models/active-model to the backend.
+        // Sibling Settings tabs cache these with a 5-minute staleTime, so without
+        // this they'd show the pre-wizard config until it expires or a reload.
+        void queryClient.invalidateQueries({ queryKey: keys.config() });
+        void queryClient.invalidateQueries({ queryKey: keys.providers() });
+        void queryClient.invalidateQueries({ queryKey: keys.models() });
       }
     },
     onError: (err) => {
@@ -195,6 +216,13 @@ export function SetupWizard() {
     },
     onError: () => {
       toast.error("Failed to cancel wizard");
+      // The X button is the only way out of the active wizard view, so leaving
+      // wizardState "active" here would trap the user. The server-side wizard is
+      // either already gone (restart) or will time out, so reset locally anyway.
+      setWizardState("idle");
+      setStep(null);
+      setAnswer("");
+      setErrorMessage(null);
     },
   });
 
@@ -241,7 +269,10 @@ export function SetupWizard() {
 
   function handleReject() {
     if (!step) return;
-    advanceMutation.mutate({ wizardId: step.wizard_id, body: { answer: "Please revise the configuration." } });
+    advanceMutation.mutate({
+      wizardId: step.wizard_id,
+      body: { answer: "Please revise the configuration." },
+    });
   }
 
   function handleCancel() {
@@ -262,7 +293,11 @@ export function SetupWizard() {
 
   const isPending =
     startMutation.isPending || advanceMutation.isPending || cancelMutation.isPending;
-  const progressPercent = step ? Math.round((step.step / step.total_steps) * 100) : 0;
+  // total_steps is 0 until the LLM has planned the run, so guard the division —
+  // otherwise the header renders a literal "NaN%" (or "Infinity%") next to
+  // "Step 0 of 0".
+  const progressPercent =
+    step && step.total_steps > 0 ? Math.round((step.step / step.total_steps) * 100) : 0;
 
   if (wizardState === "idle") {
     return (

--- a/src/pages/settings/index.tsx
+++ b/src/pages/settings/index.tsx
@@ -56,7 +56,7 @@ export function SettingsPage() {
 
           <TabsContent value="providers" className="mt-4">
             <Suspense fallback={<TabSkeleton />}>
-              <ProviderList onRequestWizard={() => setActiveTab("wizard")} />
+              <ProviderList />
             </Suspense>
           </TabsContent>
 

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,1 +1,33 @@
 import "@testing-library/jest-dom/vitest";
+
+// Node >= 22 defines a built-in global `localStorage` accessor that resolves to
+// undefined unless the process is started with --localstorage-file, and it takes
+// precedence over jsdom's implementation (under vitest's jsdom environment
+// `window === globalThis`, so both read as undefined). Install a minimal
+// in-memory Storage so persistence tests and zustand's persist middleware work.
+// No-op on runtimes that already provide a real localStorage.
+if (!globalThis.localStorage) {
+  const store = new Map<string, string>();
+  const storage = {
+    get length() {
+      return store.size;
+    },
+    clear: () => {
+      store.clear();
+    },
+    getItem: (key: string) => store.get(key) ?? null,
+    key: (index: number) => Array.from(store.keys())[index] ?? null,
+    removeItem: (key: string) => {
+      store.delete(key);
+    },
+    setItem: (key: string, value: string) => {
+      store.set(key, String(value));
+    },
+  } as unknown as Storage;
+
+  Object.defineProperty(globalThis, "localStorage", {
+    value: storage,
+    configurable: true,
+    writable: true,
+  });
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -29,5 +29,10 @@ export default defineConfig({
     setupFiles: ["./src/test/setup.ts"],
     include: ["src/**/*.test.{ts,tsx}"],
     css: false,
+    // Reset mocks between tests. Several suites share a stubGlobal'd fetch mock
+    // and queue responses with mockResolvedValueOnce; without this, an
+    // unconsumed queued response leaks into the next test and fails it far from
+    // the real cause.
+    mockReset: true,
   },
 });


### PR DESCRIPTION
## Summary

A multi-round, root-cause-driven correctness sweep of the WebUI, run after aligning the client with the **backend v0.6.0** contract. Each finding was traced with 5-whys before fixing. **~90 fixes across 61 files.**

Gate (all green): `tsc -b` · `eslint .` · Prettier · **101/101 vitest** · `vite build`.

## Highlights by area

**Backend contract (v0.6.0)**
- `POST /auth/logout` now sends the `refresh_token` body (was a silent 422 — the server session was never revoked, staying valid ~30 days)
- `DELETE /mcp/servers/{name}` 204 handled in the fetch wrapper (was `JSON.parse("")` → the delete "failed" despite succeeding)
- `request()` now throws on **any** non-2xx instead of resolving a non-envelope body (FastAPI `{"detail":…}` on 404/405/422) as a successful `undefined`
- `encodeURIComponent` on the last unencoded path params (workflow docs, chat `session_key`, provider/mcp names)

**WebSocket / streaming lifecycle (issue #29)**
- Seq now advances before the unknown-type guard (an unrecognised frame no longer triggers a reconnect loop); `discard_pending` wired
- `teardownSocket()` detaches handlers before close and guards re-entrant `connect()` + the health probe → no duplicate/orphaned sockets, no doubled streamed text
- Live slot stays mounted through the transient `agent_state:"done"` frame → no end-of-turn flash
- Pre-tool reasoning no longer leaks into the answer bubble; `statusLog` settles aborted tools
- Watchdog: not cleared by `TURN_IN_PROGRESS`, paused during tool-confirmation, re-armed on answer; tool-confirm delivery is verified and "cancel" gets the same hang-recovery fallback

**Data-fetching / concurrency**
- `isError` only takes over a pane when there's **no** cached data — a failed background refetch no longer wipes live content (16 sites, incl. the whole chat transcript)
- `cancelQueries` before the optimistic message write; stale cancel-timer cleared on a new send
- Shared-observer pending state fixed (`ConfigFlagsForm`); bulk ops reconcile via `allSettled`
- Missing invalidations added (wizard, config reload, session settings, simulate, debug toggle); **query cache cleared on login/logout** (was a cross-user data leak)

**Data integrity**
- `parseServerDate()` UTC-normalises all server timestamps (13 sites — naive-UTC values were shifted by the viewer's offset)
- `Number()` over `parseInt` for numeric inputs; "keep last N = clear all" guarded against `NaN`→0

**Accessibility & performance**
- login/register field errors associated via `aria-describedby`; simulator flags expose state via `aria-label` (were colour-only); streaming bubble drops its re-announcing `aria-live`
- Stable `useSound`/`handleDelete` identities; memoized `LogRow` + precomputed timestamps

**Structural / test infra**
- `queryClient` extracted to `src/lib/query-client.ts`; wizard progress in `src/lib/stores/wizard-store.ts` (survives Radix tab unmount)
- `src/test/setup.ts` installs an in-memory `localStorage` (Node 22+ shadows jsdom); `mockReset: true`; refreshed stale auth-store/session-socket/Cypress assertions

## Test plan
- [x] `tsc -b`, `eslint .`, `prettier --check`, `vitest` (101/101), `vite build`
- [ ] Manual smoke of chat streaming, tool confirmation, reconnect, and Settings tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
