### PR TITLE
fix(webui): reconnect livelock, cross-user state leak, +28 tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ docker-compose.cogtrix.yml
 .env.cogtrix
 .cogtrix.yml
 .claude/
+
+# Claude Code plugin/skill install artifacts (local, not shared)
+.agents/
+skills-lock.json

--- a/cypress/component/StatusBar.cy.tsx
+++ b/cypress/component/StatusBar.cy.tsx
@@ -7,6 +7,10 @@ import { mountWithProviders } from "../support/mount";
 function makeEntry(overrides: Partial<StatusEntry> = {}): StatusEntry {
   return {
     id: "call-001",
+    // toolCallId is distinct from id: `id` is the React key (unique per entry,
+    // suffixed so a repeated tool_call_id still gets a unique key), toolCallId is
+    // what updateToolEnd matches on. The real store never emits an entry without it.
+    toolCallId: "call-001",
     timestamp: Date.now(),
     tool: "search_web",
     done: false,

--- a/cypress/e2e/chat.cy.ts
+++ b/cypress/e2e/chat.cy.ts
@@ -31,7 +31,10 @@ describe("Chat page", () => {
 
     it("shows session name and agent state badge", () => {
       cy.contains(`Chat ${TEST_ID}`).should("be.visible");
-      cy.get("[role='status']").should("exist");
+      // Target the header agent-state badge specifically — `[role='status']`
+      // also matches the message bubbles, typing indicator, and connection dot,
+      // so it would pass even if the badge were missing.
+      cy.get("[aria-label^='Agent state']", { timeout: 10000 }).should("exist");
     });
 
     it("has back button linking to sessions", () => {
@@ -137,11 +140,18 @@ describe("Chat page", () => {
     });
 
     it("agent state badge updates after sending a message", () => {
+      // Baseline: idle badge reads "Ready".
+      cy.get("[aria-label='Agent state: Ready']", { timeout: 10000 }).should("exist");
+
       cy.get("[data-cy='message-input']").type("Trigger agent");
       cy.get("[data-cy='send-message']").click();
 
-      // Agent state badge should show some active state (not necessarily "Ready")
-      cy.get("[role='status']").should("be.visible");
+      // The badge must actually MOVE off "Ready" to an active state — asserting a
+      // bare `[role='status']` is visible would pass even if it never changed.
+      cy.get("[aria-label^='Agent state']", { timeout: 10000 })
+        .should("exist")
+        .invoke("attr", "aria-label")
+        .should("not.equal", "Agent state: Ready");
     });
   });
 

--- a/src/lib/api/client.test.ts
+++ b/src/lib/api/client.test.ts
@@ -171,4 +171,47 @@ describe("api convenience methods", () => {
     const [, opts] = mockFetch.mock.calls[0]!;
     expect(opts.method).toBe("DELETE");
   });
+
+  // Non-2xx responses whose body has no envelope `error` key (FastAPI emits
+  // `{"detail": ...}` for 404/405/422). These used to resolve as a successful
+  // `undefined`, so a destructive mutation reported success without doing anything.
+  it("throws on a 404 with a FastAPI {detail} body", async () => {
+    const res = {
+      ok: false,
+      status: 404,
+      text: () => Promise.resolve(JSON.stringify({ detail: "Not Found" })),
+      headers: new Headers(),
+    } as unknown as Response;
+    mockFetch.mockResolvedValueOnce(res);
+
+    await expect(request("/sessions/missing")).rejects.toMatchObject({
+      code: "HTTP_404",
+      message: "Not Found",
+    });
+  });
+
+  it("throws on a 422 whose detail is not a string (falls back to statusText)", async () => {
+    const res = {
+      ok: false,
+      status: 422,
+      statusText: "Unprocessable Entity",
+      text: () => Promise.resolve(JSON.stringify({ detail: [{ loc: ["body"], msg: "bad" }] })),
+      headers: new Headers(),
+    } as unknown as Response;
+    mockFetch.mockResolvedValueOnce(res);
+
+    await expect(request("/sessions")).rejects.toMatchObject({ code: "HTTP_422" });
+  });
+
+  it("returns undefined for a 204 No Content", async () => {
+    const res = {
+      ok: true,
+      status: 204,
+      text: () => Promise.resolve(""),
+      headers: new Headers(),
+    } as unknown as Response;
+    mockFetch.mockResolvedValueOnce(res);
+
+    await expect(request("/mcp/servers/x")).resolves.toBeUndefined();
+  });
 });

--- a/src/lib/api/types/common.test.ts
+++ b/src/lib/api/types/common.test.ts
@@ -29,3 +29,61 @@ describe("ApiError", () => {
     expect(err.stack).toBeDefined();
   });
 });
+
+describe("ApiError.getFieldErrors", () => {
+  it("flattens top-level field errors to message arrays", () => {
+    const err = new ApiError({
+      code: "VALIDATION_ERROR",
+      message: "Invalid",
+      details: {
+        fields: {
+          username: [{ code: "TOO_SHORT", message: "Too short" }],
+          email: [{ code: "INVALID_FORMAT", message: "Bad email" }],
+        },
+      },
+    });
+    expect(err.getFieldErrors()).toEqual({
+      username: ["Too short"],
+      email: ["Bad email"],
+    });
+  });
+
+  it("recurses into nested fields and joins them with a dot", () => {
+    // The backend nests errors for nested models; a non-recursive read dropped these.
+    const err = new ApiError({
+      code: "VALIDATION_ERROR",
+      message: "Invalid",
+      details: {
+        fields: {
+          config: {
+            max_steps: [{ code: "OUT_OF_RANGE", message: "1–200" }],
+          },
+        },
+      },
+    });
+    expect(err.getFieldErrors()).toEqual({ "config.max_steps": ["1–200"] });
+  });
+
+  it("collects multiple messages for one field", () => {
+    const err = new ApiError({
+      code: "VALIDATION_ERROR",
+      message: "Invalid",
+      details: {
+        fields: {
+          password: [
+            { code: "TOO_SHORT", message: "Too short" },
+            { code: "INVALID", message: "Needs a digit" },
+          ],
+        },
+      },
+    });
+    expect(err.getFieldErrors()).toEqual({ password: ["Too short", "Needs a digit"] });
+  });
+
+  it("returns {} when there are no details or no fields", () => {
+    expect(new ApiError({ code: "X", message: "m" }).getFieldErrors()).toEqual({});
+    expect(
+      new ApiError({ code: "X", message: "m", details: { other: 1 } }).getFieldErrors(),
+    ).toEqual({});
+  });
+});

--- a/src/lib/api/ws/session-socket.test.ts
+++ b/src/lib/api/ws/session-socket.test.ts
@@ -656,5 +656,124 @@ describe("SessionSocket", () => {
       expect(handlers.onAgentState).toHaveBeenCalledTimes(2);
       expect(socket.lastSeq).toBe(1);
     });
+
+    it("advances lastSeq for an unrecognised type so the next frame isn't a false gap", () => {
+      const handlers = createHandlers();
+      const socket = new SessionSocket("s1", handlers);
+      socket.connect();
+      const ws = lastCreatedWs!;
+      vi.spyOn(ws, "close");
+      ws.simulateOpen();
+
+      ws.simulateMessage({
+        type: "token",
+        session_id: "s1",
+        payload: { text: "a", final: false },
+        seq: 0,
+        ts: "t",
+      });
+      // Unknown type at seq 1 — not routed, but its seq slot must still advance.
+      ws.simulateMessage({
+        type: "totally_new_type",
+        session_id: "s1",
+        payload: {},
+        seq: 1,
+        ts: "t",
+      });
+      expect(socket.lastSeq).toBe(1);
+
+      // seq 2 is now in-order, NOT a gap.
+      ws.simulateMessage({
+        type: "token",
+        session_id: "s1",
+        payload: { text: "b", final: false },
+        seq: 2,
+        ts: "t",
+      });
+      expect(ws.close).not.toHaveBeenCalled();
+      expect(handlers.onToken).toHaveBeenCalledTimes(2);
+      expect(socket.lastSeq).toBe(2);
+    });
+
+    it("resyncs instead of livelocking when a gap persists after replay (buffer expired)", () => {
+      const handlers = createHandlers();
+      const socket = new SessionSocket("s1", handlers);
+      socket.connect();
+      const ws1 = lastCreatedWs!;
+      vi.spyOn(ws1, "close");
+      ws1.simulateOpen();
+      ws1.simulateMessage({
+        type: "agent_state",
+        session_id: "s1",
+        payload: { state: "idle" },
+        seq: 40,
+        ts: "t",
+      });
+      expect(socket.lastSeq).toBe(40);
+
+      // Forward gap → first response is to close so the server can replay.
+      ws1.simulateMessage({
+        type: "agent_state",
+        session_id: "s1",
+        payload: { state: "thinking" },
+        seq: 47,
+        ts: "t",
+      });
+      expect(ws1.close).toHaveBeenCalledOnce();
+      expect(socket.lastSeq).toBe(40);
+
+      // Drive the reconnect.
+      ws1.simulateClose(1006);
+      vi.advanceTimersByTime(1100);
+      const ws2 = lastCreatedWs!;
+      expect(ws2).not.toBe(ws1);
+      vi.spyOn(ws2, "close");
+      ws2.simulateOpen();
+
+      // Buffer expired: the server sends current state at the SAME gapped seq.
+      // Must resync (accept + route), not close again → no livelock.
+      ws2.simulateMessage({
+        type: "agent_state",
+        session_id: "s1",
+        payload: { state: "thinking" },
+        seq: 47,
+        ts: "t",
+      });
+      expect(ws2.close).not.toHaveBeenCalled();
+      expect(socket.lastSeq).toBe(47);
+      expect(handlers.onAgentState).toHaveBeenCalledTimes(2);
+
+      // Subsequent frames flow in order.
+      ws2.simulateMessage({
+        type: "agent_state",
+        session_id: "s1",
+        payload: { state: "writing" },
+        seq: 48,
+        ts: "t",
+      });
+      expect(socket.lastSeq).toBe(48);
+    });
+  });
+
+  describe("reconnect circuit breaker", () => {
+    it("gives up with onReconnectFailed after MAX_RECONNECT_ATTEMPTS without a successful open", () => {
+      const handlers = createHandlers();
+      const socket = new SessionSocket("s1", handlers);
+      socket.connect();
+
+      // Repeatedly drop before opening (so onopen never resets the counter).
+      lastCreatedWs!.simulateClose(1006); // attempt 1
+      for (let i = 2; i <= 10; i++) {
+        vi.advanceTimersByTime(30_000);
+        lastCreatedWs!.simulateClose(1006); // attempts 2..10
+      }
+      expect(handlers.onReconnecting).toHaveBeenCalledTimes(10);
+      expect(handlers.onReconnectFailed).not.toHaveBeenCalled();
+
+      // 11th drop trips the breaker.
+      vi.advanceTimersByTime(30_000);
+      lastCreatedWs!.simulateClose(1006);
+      expect(handlers.onReconnectFailed).toHaveBeenCalledOnce();
+    });
   });
 });

--- a/src/lib/api/ws/session-socket.ts
+++ b/src/lib/api/ws/session-socket.ts
@@ -67,6 +67,11 @@ export class SessionSocket {
   private intentionallyClosed = false;
   private reconnectAttempts = 0;
   private healthProbeInFlight = false;
+  // True after we closed for a forward gap and are awaiting the server's replay.
+  // If the next connection STILL shows a gap, the replay buffer expired and we
+  // resync instead of re-closing (prevents a reconnect livelock). Persists across
+  // the reconnect on purpose; cleared once any frame is accepted.
+  private awaitingGapReplay = false;
 
   constructor(
     private readonly sessionId: string,
@@ -121,13 +126,24 @@ export class SessionSocket {
             return;
           }
           if (msg.seq !== this._lastSeq + 1) {
-            // True forward gap — close and reconnect so the server replays from
-            // last_seq. Do NOT update _lastSeq so replay starts from the correct
-            // position.
-            this.ws?.close();
-            return;
+            // Forward gap. First time: close so the server replays from last_seq
+            // on reconnect (do NOT advance _lastSeq, so replay resumes correctly).
+            // But if we ALREADY closed for a gap and reconnected and the gap is
+            // STILL here, the server's replay buffer has expired — per the WS
+            // protocol it then sends current state only, at a seq beyond
+            // last_seq+1. Closing again would livelock forever (and onopen resets
+            // reconnectAttempts, so the circuit breaker never trips). Resync
+            // instead: adopt the server's seq and let the onOpen REST refetch
+            // fill the history hole.
+            if (!this.awaitingGapReplay) {
+              this.awaitingGapReplay = true;
+              this.ws?.close();
+              return;
+            }
           }
         }
+        // In-order frame, or a resync after an unfillable gap: accept it.
+        this.awaitingGapReplay = false;
         this._lastSeq = msg.seq;
       }
       if (!VALID_SERVER_MESSAGE_TYPES.includes(msg.type as string)) {

--- a/src/lib/stores/auth-store.ts
+++ b/src/lib/stores/auth-store.ts
@@ -2,7 +2,18 @@ import { create } from "zustand";
 import { api } from "../api/client";
 import { setTokens, clearTokens, getRefreshToken } from "../api/tokens";
 import { queryClient } from "../query-client";
+import { useWizardStore } from "./wizard-store";
+import { useLogViewerStore } from "./log-viewer-store";
 import type { TokenPair, UserOut } from "../api/types";
+
+/** Wipe all per-user client state on an identity change. queryClient holds server
+ *  data; the wizard/log-viewer stores are module singletons that would otherwise
+ *  leak one user's config/logs to the next user on the same tab. */
+function clearClientState() {
+  queryClient.clear();
+  useWizardStore.getState().reset();
+  useLogViewerStore.getState().reset();
+}
 
 interface AuthState {
   user: UserOut | null;
@@ -25,8 +36,8 @@ export const useAuthStore = create<AuthState>((set) => ({
     set({ isLoading: true });
     // Also clear here, not just on logout: a session can end without logout()
     // running (expired refresh token redirecting to /login), and that path would
-    // otherwise leave the previous user's cache intact.
-    queryClient.clear();
+    // otherwise leave the previous user's state intact.
+    clearClientState();
     try {
       const tokens = await api.post<TokenPair>("/auth/login", { username, password });
       setTokens(tokens);
@@ -59,9 +70,9 @@ export const useAuthStore = create<AuthState>((set) => ({
       clearTokens();
       set({ user: null, isAuthenticated: false, isAdmin: false });
       // Sessions/config/providers/models are cached with a 5-minute staleTime and
-      // gcTime, so without this the next user to sign in on this tab is served
-      // the previous user's data immediately and without a refetch.
-      queryClient.clear();
+      // gcTime, and the wizard/log-viewer stores hold config/log content — without
+      // this the next user to sign in on this tab sees the previous user's data.
+      clearClientState();
     }
   },
 }));

--- a/src/lib/stores/log-viewer-store.test.ts
+++ b/src/lib/stores/log-viewer-store.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { useLogViewerStore, MAX_LOG_LINES } from "./log-viewer-store";
+import type { LogLinePayload } from "@/lib/api/types/system";
+
+function line(overrides: Partial<LogLinePayload> = {}): LogLinePayload {
+  return {
+    type: "log_line",
+    level: "INFO",
+    logger: "cogtrix",
+    message: "hello",
+    timestamp: "2026-07-24T12:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("log-viewer-store", () => {
+  beforeEach(() => {
+    useLogViewerStore.getState().reset();
+  });
+
+  it("appends lines with a monotonic key and a precomputed displayTime", () => {
+    useLogViewerStore.getState().appendLine(line({ message: "a" }));
+    useLogViewerStore.getState().appendLine(line({ message: "b" }));
+    const { lines } = useLogViewerStore.getState();
+    expect(lines.map((l) => l.message)).toEqual(["a", "b"]);
+    expect(lines[0]!.key).not.toBe(lines[1]!.key);
+    // displayTime is derived once at append (formatted HH:MM:SS), not the raw ISO.
+    expect(lines[0]!.displayTime).toMatch(/\d{2}:\d{2}:\d{2}/);
+  });
+
+  it("caps the ring buffer at MAX_LOG_LINES, keeping the most recent", () => {
+    for (let i = 0; i < MAX_LOG_LINES + 50; i++) {
+      useLogViewerStore.getState().appendLine(line({ message: `m${i}` }));
+    }
+    const { lines } = useLogViewerStore.getState();
+    expect(lines.length).toBe(MAX_LOG_LINES);
+    expect(lines.slice(-1)[0]!.message).toBe(`m${MAX_LOG_LINES + 49}`);
+  });
+
+  it("formats a Python comma-millisecond timestamp", () => {
+    useLogViewerStore.getState().appendLine(line({ timestamp: "2026-07-24 12:34:56,789" }));
+    expect(useLogViewerStore.getState().lines.slice(-1)[0]!.displayTime).toBe("12:34:56");
+  });
+
+  it("passes an unparseable timestamp through unchanged", () => {
+    useLogViewerStore.getState().appendLine(line({ timestamp: "not-a-date" }));
+    expect(useLogViewerStore.getState().lines.slice(-1)[0]!.displayTime).toBe("not-a-date");
+  });
+
+  it("reset() clears lines, keys, and connection state (cross-user leak guard)", () => {
+    const s = useLogViewerStore.getState();
+    s.appendLine(line());
+    s.setConnectionStatus("connected");
+    s.setUserDisconnected(true);
+    s.reset();
+    const after = useLogViewerStore.getState();
+    expect(after.lines).toEqual([]);
+    expect(after.nextLineKey).toBe(0);
+    expect(after.connectionStatus).toBe("disconnected");
+    expect(after.userDisconnected).toBe(false);
+  });
+});

--- a/src/lib/stores/log-viewer-store.ts
+++ b/src/lib/stores/log-viewer-store.ts
@@ -37,6 +37,9 @@ interface LogViewerState {
   setUserDisconnected: (value: boolean) => void;
   appendLine: (payload: LogLinePayload) => void;
   clearLines: () => void;
+  /** Full reset. Called on login/logout so buffered admin log lines from one
+   *  session don't carry over to the next user on the same tab. */
+  reset: () => void;
 }
 
 export const useLogViewerStore = create<LogViewerState>((set) => ({
@@ -68,4 +71,13 @@ export const useLogViewerStore = create<LogViewerState>((set) => ({
   },
 
   clearLines: () => set({ lines: [], nextLineKey: 0 }),
+
+  reset: () =>
+    set({
+      level: "DEBUG",
+      lines: [],
+      nextLineKey: 0,
+      connectionStatus: "disconnected",
+      userDisconnected: false,
+    }),
 }));

--- a/src/lib/stores/streaming-store.test.ts
+++ b/src/lib/stores/streaming-store.test.ts
@@ -9,6 +9,9 @@ describe("streaming store", () => {
   beforeEach(() => {
     act(() => {
       getStore().reset();
+      // reset() intentionally preserves statusLog; clear it so statusLog
+      // assertions don't see cross-test accumulation.
+      getStore().clearStatusLog();
       getStore().setConnectionStatus("closed");
     });
   });
@@ -134,5 +137,73 @@ describe("streaming store", () => {
     expect(state.pendingConfirmation).toBeNull();
     expect(state.toolActivities.size).toBe(0);
     expect(state.connectionStatus).toBe("open");
+  });
+
+  it("reset() settles a still-running statusLog entry as aborted", () => {
+    act(() => {
+      getStore().addToolStart("search", "tc-1", {});
+    });
+    expect(getStore().statusLog.slice(-1)[0]).toMatchObject({ done: false, error: null });
+
+    act(() => {
+      getStore().reset();
+    });
+    // The tool never got a tool_end (turn cancelled/timed out) — must not stay a
+    // perpetual spinner.
+    expect(getStore().statusLog.slice(-1)[0]).toMatchObject({ done: true, error: "aborted" });
+  });
+
+  it("addToolStart cancels a pending RAF flush so pre-tool tokens don't leak", () => {
+    act(() => {
+      getStore().appendToken("reasoning "); // schedules a RAF, not yet flushed
+      getStore().addToolStart("search", "tc-1", {}); // must cancel it + clear buffer
+    });
+    act(() => {
+      // Force any surviving RAF to run; the buffer must remain empty.
+      flushPendingTokens();
+    });
+    expect(getStore().streamingBuffer).toBe("");
+  });
+
+  it("gives a repeated tool_call_id distinct statusLog ids", () => {
+    act(() => {
+      getStore().addToolStart("search", "dup", {});
+      getStore().addToolStart("search", "dup", {});
+    });
+    const entries = getStore().statusLog.filter((e) => e.toolCallId === "dup");
+    expect(entries).toHaveLength(2);
+    expect(entries[0]!.id).not.toBe(entries[1]!.id);
+  });
+
+  it("updateToolEnd settles only the most recent un-done entry for a repeated id", () => {
+    act(() => {
+      getStore().addToolStart("search", "dup", {});
+      getStore().addToolStart("search", "dup", {});
+      getStore().updateToolEnd("dup", 123, null);
+    });
+    const entries = getStore().statusLog.filter((e) => e.toolCallId === "dup");
+    // First invocation still running; only the latest settled.
+    expect(entries[0]!.done).toBe(false);
+    expect(entries[1]).toMatchObject({ done: true, durationMs: 123 });
+  });
+
+  it("clearStreamingBuffer empties the buffer without touching agent state", () => {
+    act(() => {
+      getStore().setAgentState("writing");
+      getStore().appendToken("partial");
+      getStore().clearStreamingBuffer();
+      flushPendingTokens();
+    });
+    expect(getStore().streamingBuffer).toBe("");
+    expect(getStore().agentState).toBe("writing");
+  });
+
+  it("caps statusLog at 100 entries", () => {
+    act(() => {
+      for (let i = 0; i < 130; i++) getStore().addToolStart("t", `tc-${i}`, {});
+    });
+    expect(getStore().statusLog.length).toBe(100);
+    // Ring buffer keeps the most recent.
+    expect(getStore().statusLog.slice(-1)[0]!.toolCallId).toBe("tc-129");
   });
 });

--- a/src/lib/stores/wizard-store.ts
+++ b/src/lib/stores/wizard-store.ts
@@ -23,15 +23,23 @@ interface WizardStore {
   setStep: (step: WizardStepOut | null) => void;
   setAnswer: (answer: string) => void;
   setErrorMessage: (message: string | null) => void;
+  /** Clear all progress. Called on login/logout so one user's wizard state
+   *  (which holds provider/model config in `step`) can't leak to the next. */
+  reset: () => void;
 }
 
-export const useWizardStore = create<WizardStore>((set) => ({
-  wizardState: "idle",
+const initialWizardState = {
+  wizardState: "idle" as WizardState,
   step: null,
   answer: "",
   errorMessage: null,
+};
+
+export const useWizardStore = create<WizardStore>((set) => ({
+  ...initialWizardState,
   setWizardState: (wizardState) => set({ wizardState }),
   setStep: (step) => set({ step }),
   setAnswer: (answer) => set({ answer }),
   setErrorMessage: (errorMessage) => set({ errorMessage }),
+  reset: () => set({ ...initialWizardState }),
 }));

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,4 +1,51 @@
-import { cn } from "./utils";
+import { cn, parseServerDate, formatUptime } from "./utils";
+
+describe("parseServerDate", () => {
+  it("treats an offset-less timestamp as UTC (not local)", () => {
+    // The bug this guards: ES parses a date-TIME with no offset as LOCAL time, so
+    // a naive-UTC server value would shift by the viewer's offset. Both forms must
+    // resolve to the same instant.
+    const naive = parseServerDate("2026-07-24T12:00:00");
+    const explicit = parseServerDate("2026-07-24T12:00:00Z");
+    expect(naive.getTime()).toBe(explicit.getTime());
+    expect(naive.toISOString()).toBe("2026-07-24T12:00:00.000Z");
+  });
+
+  it("leaves an already-Z timestamp unchanged", () => {
+    expect(parseServerDate("2026-07-24T12:00:00Z").toISOString()).toBe("2026-07-24T12:00:00.000Z");
+  });
+
+  it("respects an explicit numeric offset without double-suffixing", () => {
+    expect(parseServerDate("2026-07-24T12:00:00+05:30").toISOString()).toBe(
+      "2026-07-24T06:30:00.000Z",
+    );
+    expect(parseServerDate("2026-07-24T12:00:00-04:00").toISOString()).toBe(
+      "2026-07-24T16:00:00.000Z",
+    );
+  });
+});
+
+describe("formatUptime", () => {
+  it("shows seconds under a minute", () => {
+    expect(formatUptime(0)).toBe("0s");
+    expect(formatUptime(59)).toBe("59s");
+  });
+
+  it("shows minutes and seconds under an hour", () => {
+    expect(formatUptime(60)).toBe("1m 0s");
+    expect(formatUptime(3599)).toBe("59m 59s");
+  });
+
+  it("shows hours/minutes/seconds under a day", () => {
+    expect(formatUptime(3600)).toBe("1h 0m 0s");
+    expect(formatUptime(86399)).toBe("23h 59m 59s");
+  });
+
+  it("shows days/hours/minutes at a day or more", () => {
+    expect(formatUptime(86400)).toBe("1d 0h 0m");
+    expect(formatUptime(90061)).toBe("1d 1h 1m");
+  });
+});
 
 describe("cn() utility", () => {
   it("merges class names", () => {


### PR DESCRIPTION
## Summary

Follow-up hardening from a fresh audit round — an **adversarial self-review of the prior 90-fix sweep** plus test-quality, state-machine-invariant, and config lenses. The self-review validated the earlier fixes as correct; these are the *new* findings.

Gate: `tsc -b` · `eslint .` · Prettier · **129 unit tests (was 101)** · `vite build`.

## Bugs fixed

**Reconnect livelock (found by a model-checker-style invariant pass).** After a disconnect long enough for the server's ~30s replay buffer to expire, the stream resumes at `seq > _lastSeq+1` (WS protocol §7: "current state only"). The client treated that as a forward gap and re-closed forever — and because `onopen` resets `reconnectAttempts`, the 10-attempt breaker never tripped, pinning the user in a ~1s flap with no "please refresh" escape. Now: the first gap still closes for replay, but a gap that **persists after reconnect** resyncs (adopt the server's seq, rely on the onOpen REST refetch) instead of livelocking.

**Cross-user state leak (a regression from the prior round).** The new `wizard-store` singleton — and `log-viewer-store` — weren't reset on logout, so User A's wizard config / admin logs showed to User B on the same tab. Added `reset()` to both, called from a `clearClientState()` helper in `auth-store` login **and** logout (alongside the existing `queryClient.clear()`).

## Docs
Documented the `bearer` `Sec-WebSocket-Protocol` auth method in `websocket-protocol.md` (backend v0.6.0 supports it, #1887) — the local doc was stale. `/ws/v1/logs` legitimately still uses the query param.

## Tests
- **Fixed 2 incorrect specs:** `chat.cy.ts` asserted the multi-match `[role='status']` (5 elements on a chat page — passes vacuously) → now targets the agent-state badge and asserts it moves off "Ready"; `StatusBar` fixture was missing the required `toolCallId`.
- **+28 unit tests** locking in the recently changed pure logic: `request()` non-2xx `{detail}`/204, `ApiError.getFieldErrors` nested recursion, `parseServerDate`/`formatUptime`, streaming-store aborted-settle / RAF-cancel / duplicate-id / ring-cap, session-socket unknown-type seq advance / **gap-resync** / backoff breaker, and a new `log-viewer-store` suite.

## Also
`.gitignore` now excludes local Claude Code plugin/skill artifacts (`.agents/`, `skills-lock.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
