### PR TITLE
fix(infra,deps): gzip JS bundle, no-store SPA fallback, security dep bumps

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -19,7 +19,9 @@ server {
     # Compression
     gzip on;
     gzip_vary on;
-    gzip_types text/plain text/css application/javascript application/json image/svg+xml;
+    # nginx >= 1.25 maps .js to text/javascript (not application/javascript), so
+    # BOTH must be listed or the main JS bundle ships uncompressed.
+    gzip_types text/plain text/css text/javascript application/javascript application/json image/svg+xml;
     gzip_min_length 256;
     gzip_comp_level 6;
     client_max_body_size 50m;
@@ -84,8 +86,19 @@ server {
         add_header X-Content-Type-Options "nosniff" always;
     }
 
-    # SPA fallback — serve index.html for client-side routes
+    # SPA fallback — serve index.html for client-side routes.
+    # Deep-link routes (e.g. /sessions) are served the index.html body here, NOT
+    # via `location = /index.html`, so the no-store header must be repeated or the
+    # browser heuristically caches a stale HTML that references purged hashed
+    # assets after a deploy. (add_header in a location replaces the server-level
+    # headers, so the security headers are repeated too.)
     location / {
         try_files $uri $uri/ /index.html;
+        add_header Cache-Control "no-store, no-cache, must-revalidate" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header X-Frame-Options "DENY" always;
+        add_header X-XSS-Protection "1; mode=block" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' ws: wss:; font-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'" always;
     }
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-markdown": "^10.1.0",
-    "react-router-dom": "^7.14.0",
+    "react-router-dom": "^7.15.1",
     "react-syntax-highlighter": "^16.1.1",
     "rehype-raw": "^7.0.0",
     "rehype-sanitize": "^6.0.0",
@@ -55,7 +55,7 @@
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.65.0",
     "unified": "^11.0.5",
-    "vite": "^7.3.1",
+    "vite": "^7.3.5",
     "vitest": "^4.1.0"
   },
   "packageManager": "pnpm@10.30.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     dependencies:
       '@tailwindcss/vite':
         specifier: ^4.2.2
-        version: 4.2.2(vite@7.3.1(@types/node@26.1.1)(jiti@2.6.1)(lightningcss@1.32.0))
+        version: 4.2.2(vite@7.3.6(@types/node@26.1.1)(jiti@2.6.1)(lightningcss@1.32.0))
       '@tanstack/react-query':
         specifier: ^5.99.0
         version: 5.99.0(react@19.2.4)
@@ -39,8 +39,8 @@ importers:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.2.14)(react@19.2.4)
       react-router-dom:
-        specifier: ^7.14.0
-        version: 7.14.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: ^7.15.1
+        version: 7.18.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react-syntax-highlighter:
         specifier: ^16.1.1
         version: 16.1.1(react@19.2.4)
@@ -89,7 +89,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^5.2.0
-        version: 5.2.0(vite@7.3.1(@types/node@26.1.1)(jiti@2.6.1)(lightningcss@1.32.0))
+        version: 5.2.0(vite@7.3.6(@types/node@26.1.1)(jiti@2.6.1)(lightningcss@1.32.0))
       cypress:
         specifier: ^15.19.0
         version: 15.19.0
@@ -118,11 +118,11 @@ importers:
         specifier: ^11.0.5
         version: 11.0.5
       vite:
-        specifier: ^7.3.1
-        version: 7.3.1(@types/node@26.1.1)(jiti@2.6.1)(lightningcss@1.32.0)
+        specifier: ^7.3.5
+        version: 7.3.6(@types/node@26.1.1)(jiti@2.6.1)(lightningcss@1.32.0)
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@types/node@26.1.1)(jsdom@29.0.2)(vite@7.3.1(@types/node@26.1.1)(jiti@2.6.1)(lightningcss@1.32.0))
+        version: 4.1.0(@types/node@26.1.1)(jsdom@29.0.2)(vite@7.3.6(@types/node@26.1.1)(jiti@2.6.1)(lightningcss@1.32.0))
 
 packages:
 
@@ -2983,15 +2983,15 @@ packages:
       '@types/react':
         optional: true
 
-  react-router-dom@7.14.0:
-    resolution: {integrity: sha512-2G3ajSVSZMEtmTjIklRWlNvo8wICEpLihfD/0YMDxbWK2UyP5EGfnoIn9AIQGnF3G/FX0MRbHXdFcD+rL1ZreQ==}
+  react-router-dom@7.18.1:
+    resolution: {integrity: sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
       react-dom: '>=18'
 
-  react-router@7.14.0:
-    resolution: {integrity: sha512-m/xR9N4LQLmAS0ZhkY2nkPA1N7gQ5TUVa5n8TgANuDTARbn1gt+zLPXEm7W0XDTbrQ2AJSJKhoa6yx1D8BcpxQ==}
+  react-router@7.18.1:
+    resolution: {integrity: sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
@@ -3399,8 +3399,8 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
-  vite@7.3.1:
-    resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
+  vite@7.3.6:
+    resolution: {integrity: sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -4816,12 +4816,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.2.2
       '@tailwindcss/oxide-win32-x64-msvc': 4.2.2
 
-  '@tailwindcss/vite@4.2.2(vite@7.3.1(@types/node@26.1.1)(jiti@2.6.1)(lightningcss@1.32.0))':
+  '@tailwindcss/vite@4.2.2(vite@7.3.6(@types/node@26.1.1)(jiti@2.6.1)(lightningcss@1.32.0))':
     dependencies:
       '@tailwindcss/node': 4.2.2
       '@tailwindcss/oxide': 4.2.2
       tailwindcss: 4.2.2
-      vite: 7.3.1(@types/node@26.1.1)(jiti@2.6.1)(lightningcss@1.32.0)
+      vite: 7.3.6(@types/node@26.1.1)(jiti@2.6.1)(lightningcss@1.32.0)
 
   '@tanstack/query-core@5.99.0': {}
 
@@ -5039,7 +5039,7 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitejs/plugin-react@5.2.0(vite@7.3.1(@types/node@26.1.1)(jiti@2.6.1)(lightningcss@1.32.0))':
+  '@vitejs/plugin-react@5.2.0(vite@7.3.6(@types/node@26.1.1)(jiti@2.6.1)(lightningcss@1.32.0))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -5047,7 +5047,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.3
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 7.3.1(@types/node@26.1.1)(jiti@2.6.1)(lightningcss@1.32.0)
+      vite: 7.3.6(@types/node@26.1.1)(jiti@2.6.1)(lightningcss@1.32.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -5060,13 +5060,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.1.0(vite@7.3.1(@types/node@26.1.1)(jiti@2.6.1)(lightningcss@1.32.0))':
+  '@vitest/mocker@4.1.0(vite@7.3.6(@types/node@26.1.1)(jiti@2.6.1)(lightningcss@1.32.0))':
     dependencies:
       '@vitest/spy': 4.1.0
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@26.1.1)(jiti@2.6.1)(lightningcss@1.32.0)
+      vite: 7.3.6(@types/node@26.1.1)(jiti@2.6.1)(lightningcss@1.32.0)
 
   '@vitest/pretty-format@4.1.0':
     dependencies:
@@ -6624,13 +6624,13 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  react-router-dom@7.14.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  react-router-dom@7.18.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      react-router: 7.14.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react-router: 7.18.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
-  react-router@7.14.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  react-router@7.18.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       cookie: 1.1.1
       react: 19.2.4
@@ -7086,24 +7086,24 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@7.3.1(@types/node@26.1.1)(jiti@2.6.1)(lightningcss@1.32.0):
+  vite@7.3.6(@types/node@26.1.1)(jiti@2.6.1)(lightningcss@1.32.0):
     dependencies:
       esbuild: 0.27.3
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
       postcss: 8.5.8
       rollup: 4.59.0
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 26.1.1
       fsevents: 2.3.3
       jiti: 2.6.1
       lightningcss: 1.32.0
 
-  vitest@4.1.0(@types/node@26.1.1)(jsdom@29.0.2)(vite@7.3.1(@types/node@26.1.1)(jiti@2.6.1)(lightningcss@1.32.0)):
+  vitest@4.1.0(@types/node@26.1.1)(jsdom@29.0.2)(vite@7.3.6(@types/node@26.1.1)(jiti@2.6.1)(lightningcss@1.32.0)):
     dependencies:
       '@vitest/expect': 4.1.0
-      '@vitest/mocker': 4.1.0(vite@7.3.1(@types/node@26.1.1)(jiti@2.6.1)(lightningcss@1.32.0))
+      '@vitest/mocker': 4.1.0(vite@7.3.6(@types/node@26.1.1)(jiti@2.6.1)(lightningcss@1.32.0))
       '@vitest/pretty-format': 4.1.0
       '@vitest/runner': 4.1.0
       '@vitest/snapshot': 4.1.0
@@ -7120,7 +7120,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.3.1(@types/node@26.1.1)(jiti@2.6.1)(lightningcss@1.32.0)
+      vite: 7.3.6(@types/node@26.1.1)(jiti@2.6.1)(lightningcss@1.32.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 26.1.1


### PR DESCRIPTION
## Summary

First pass over the **deployment/infra config and dependency alerts** — areas the prior code-focused audit rounds never touched. Small, verified, independent of the open PR #61.

Gate: `tsc -b` · `eslint .` · **101 unit tests** · `vite build` — all green with the bumped deps.

## nginx (`docker/nginx.conf`)
- **JS bundle was shipping uncompressed.** nginx ≥ 1.25 serves `.js` as `text/javascript` (not `application/javascript`), which wasn't in `gzip_types` — so the ~240 KB main bundle went out ungzipped. Added `text/javascript` → ~77 KB over the wire.
- **SPA deep-links could serve stale HTML.** The `no-store` header was only on the literal `/index.html`; deep-link routes (e.g. `/sessions`) get the index body via the `try_files` fallback and were heuristically cacheable, so after a deploy a browser could load stale HTML referencing purged hashed assets. Added `Cache-Control: no-store` (+ the security headers, since `add_header` in a location replaces the server-level ones) to the fallback.

## Dependencies (Dependabot)
- **`react-router-dom` ^7.13.1 → ^7.15.1** (resolves 7.18.1) — the **one runtime-bundled** dep with open advisories (high/med/low; fixed across 7.14–7.15.1).
- **`vite` ^7.3.1 → ^7.3.5** (resolves 7.3.6) — dev build-tool advisory.

**Why not the other ~28 alerts:** this is a static SPA — the production artifact is nginx-served files with no Node runtime. The remaining alerts are dev/build-time transitives (mostly via Cypress: `systeminformation`, `form-data`, `tmp`, `qs`, `lodash`, `undici`, `esbuild`, `@babel`) that never reach the shipped bundle. Forcing `overrides` on Cypress's tree risks breaking it for zero production benefit, so they're intentionally left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
